### PR TITLE
Add Allowed() and Denied() methods to Decision alias type

### DIFF
--- a/cedar.go
+++ b/cedar.go
@@ -146,6 +146,14 @@ const (
 	Deny  = Decision(false)
 )
 
+func (a Decision) Allowed() bool {
+	return a == Allow
+}
+
+func (a Decision) Denied() bool {
+	return a == Deny
+}
+
 func (a Decision) String() string {
 	if a {
 		return "allow"


### PR DESCRIPTION
Adds Allowed() and Denied() methods to the Decision type to allow for less verbose handling of authorization results.

```
result, _ := policyset.IsAuthorized(entities, request)
if result.Allowed() {
    // do thing
}
```


