### PR TITLE
Fix corpus tests

### DIFF
--- a/integration_tests/corpus_test.go
+++ b/integration_tests/corpus_test.go
@@ -20,10 +20,10 @@ var integrationFS embed.FS
 type corpusTest struct {
 	Schema         string `json:"schema"`
 	Policies       string `json:"policies"`
-	ShouldValidate bool   `json:"should_validate"`
+	ShouldValidate bool   `json:"shouldValidate"`
 	Entities       string `json:"entities"`
 	Requests       []struct {
-		Desc      string       `json:"desc"`
+		Desc      string       `json:"description"`
 		Principal jsonEntity   `json:"principal"`
 		Action    jsonEntity   `json:"action"`
 		Resource  jsonEntity   `json:"resource"`
@@ -45,13 +45,7 @@ func TestCorpus(t *testing.T) {
 			t.Fatal("err loading tests", p, err)
 		}
 		for _, tn := range more {
-			if strings.Contains(tn, "schema_") {
-				continue
-			}
-			if strings.Contains(tn, ".cedarschema.json") {
-				continue
-			}
-			if strings.Contains(tn, ".entities.json") {
+			if strings.Contains(tn, "entities.json") {
 				continue
 			}
 			tests = append(tests, tn)
@@ -115,7 +109,7 @@ func TestCorpus(t *testing.T) {
 						Resource:  cedar.EntityUID(q.Resource),
 						Context:   q.Context,
 					})
-					if ok != (q.Decision == "Allow") {
+					if ok != (q.Decision == "allow") {
 						t.Fatalf("got %v want %v", ok, q.Decision)
 					}
 					var errors []string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Hi 👋 I've been working on standardizing Cedar's JSON interfaces (including the integration tests), and made a couple edits recently that will affect `cedar-go`. I believe the changes I've made here will fix any breaks.

Tested with: `go test -count=1 -v -tags corpus ./integration_tests/...`

Related PRs:
* Update to `cedar`: https://github.com/cedar-policy/cedar/pull/837
* Update to `cedar-integration-tests`: https://github.com/cedar-policy/cedar-integration-tests/pull/4
