### PR TITLE
Set Go 1.22 as min Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cedar-policy/cedar-go
 
-go 1.22.0
+go 1.22
 
 require golang.org/x/exp v0.0.0-20240222234643-814bf88cf225


### PR DESCRIPTION
*Issue #, if available:* https://github.com/cedar-policy/cedar-go/issues/17

*Description of changes:* Sets Go 1.22 as the minimum Go version.


