### PR TITLE
IDX-65: Set default shell to bash

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -6,6 +6,9 @@ on:
   # push:
 
 jobs:
+  defaults:
+    run:
+      shell: bash
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:* IDX-65

*Description of changes:* 

This sets the `-o pipefail` behavior that you might expect to be a default (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference). Without this setting, `go test -count=1 -v -tags corpus ./integration_tests/... | tail` will always return a success error code.
