### PR TITLE
cedar: change JSON marshaling of the Position struct to use conventional lower case keys

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -97,10 +97,17 @@ func (p *Policy) Effect() Effect {
 
 // A Position describes an arbitrary source position including the file, line, and column location.
 type Position struct {
-	Filename string // optional name of the source file for the enclosing policy, "" if the source is unknown or not a named file
-	Offset   int    // byte offset, starting at 0
-	Line     int    // line number, starting at 1
-	Column   int    // column number, starting at 1 (character count per line)
+	// Filename is the optional name of the source file for the enclosing policy, "" if the source is unknown or not a named file
+	Filename string `json:"filename"`
+
+	// Offset is the byte offset, starting at 0
+	Offset int `json:"offset"`
+
+	// Line is the line number, starting at 1
+	Line int `json:"line"`
+
+	// Column is the column number, starting at 1 (character count per line)
+	Column int `json:"column"`
 }
 
 // Position retrieves the position of this policy.

--- a/policy_test.go
+++ b/policy_test.go
@@ -108,3 +108,21 @@ func TestUnmarshalCedarPolicyErr(t *testing.T) {
 	err := p.UnmarshalCedar([]byte("!@#$"))
 	testutil.Error(t, err)
 }
+
+func TestPositionJSON(t *testing.T) {
+	t.Parallel()
+	p := cedar.Position{Filename: "foo.cedar", Offset: 1, Line: 2, Column: 3}
+
+	marshaled, err := json.MarshalIndent(p, "", "\t")
+	testutil.OK(t, err)
+
+	var want bytes.Buffer
+	_ = json.Indent(&want, []byte(`{ "filename": "foo.cedar", "offset": 1, "line": 2, "column": 3 }`), "", "\t")
+
+	testutil.Equals(t, string(marshaled), want.String())
+
+	var unmarshaled cedar.Position
+	testutil.OK(t, json.Unmarshal(want.Bytes(), &unmarshaled))
+
+	testutil.Equals(t, unmarshaled, p)
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Technically, this is a breaking change and will require us to go to 0.3.0.
