### PR TITLE
This commit adds an extension type, datetime, to Cedar Go.

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -534,6 +534,33 @@ func TestIsAuthorized(t *testing.T) {
 			DiagErr:   1,
 		},
 		{
+			Name: "permit-when-datetime",
+			Policy: `permit(principal,action,resource) when {
+				datetime("1970-01-01T09:08:07Z") < (datetime("1970-02-01")) &&
+				datetime("1970-01-01T09:08:07Z") <= (datetime("1970-02-01")) &&
+				datetime("1970-01-01T09:08:07Z") > (datetime("1970-01-01")) &&
+				datetime("1970-01-01T09:08:07Z") >= (datetime("1970-01-01")) &&
+        datetime("1970-01-01T09:08:07Z").toDate() == datetime("1970-01-01")};`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      true,
+			DiagErr:   0,
+		},
+		{
+			Name:      "permit-when-datetime-fun-wrong-arity",
+			Policy:    `permit(principal,action,resource) when { datetime("1970-01-01", "UTC") };`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      false,
+			DiagErr:   1,
+		},
+		{
 			Name: "permit-when-ip",
 			Policy: `permit(principal,action,resource) when {
 				ip("1.2.3.4").isIpv4() &&

--- a/internal/eval/convert.go
+++ b/internal/eval/convert.go
@@ -36,6 +36,8 @@ func toEval(n ast.IsNode) Evaler {
 				return newIPLiteralEval(toEval(v.Args[0]))
 			case v.Name == "decimal":
 				return newDecimalLiteralEval(toEval(v.Args[0]))
+			case v.Name == "datetime":
+				return newDatetimeLiteralEval(toEval(v.Args[0]))
 
 			case v.Name == "lessThan":
 				return newDecimalLessThanEval(toEval(v.Args[0]), toEval(v.Args[1]))
@@ -56,6 +58,9 @@ func toEval(n ast.IsNode) Evaler {
 				return newIPTestEval(toEval(v.Args[0]), ipTestMulticast)
 			case v.Name == "isInRange":
 				return newIPIsInRangeEval(toEval(v.Args[0]), toEval(v.Args[1]))
+
+			case v.Name == "toDate":
+				return newToDateEval(toEval(v.Args[0]))
 			}
 		}
 		return newErrorEval(fmt.Errorf("%w: %s", errUnknownExtensionFunction, v.Name))
@@ -101,13 +106,13 @@ func toEval(n ast.IsNode) Evaler {
 	case ast.NodeTypeNotEquals:
 		return newNotEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThan:
-		return newLongGreaterThanEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualGreaterThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThanOrEqual:
-		return newLongGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThan:
-		return newLongLessThanEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualLessThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThanOrEqual:
-		return newLongLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeSub:
 		return newSubtractEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeAdd:

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -210,6 +210,18 @@ func TestToEval(t *testing.T) {
 			testutil.OK,
 		},
 		{
+			"datetime",
+			ast.ExtensionCall("datetime", ast.String("1970-01-01T00:00:00.001Z")),
+			types.UnsafeDatetime(1),
+			testutil.OK,
+		},
+		{
+			"toDate",
+			ast.ExtensionCall("toDate", ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDatetime(0),
+			testutil.OK,
+		},
+		{
 			"lessThan",
 			ast.ExtensionCall("lessThan", ast.Value(types.UnsafeDecimal(42.0)), ast.Value(types.UnsafeDecimal(43))),
 			types.True,

--- a/internal/eval/util.go
+++ b/internal/eval/util.go
@@ -12,6 +12,8 @@ func TypeName(v types.Value) string {
 		return "bool"
 	case types.Decimal:
 		return "decimal"
+	case types.Datetime:
+		return "datetime"
 	case types.EntityUID:
 		return fmt.Sprintf("(entity of type `%s`)", t.Type)
 	case types.IPAddr:
@@ -77,6 +79,14 @@ func ValueToEntity(v types.Value) (types.EntityUID, error) {
 		return types.EntityUID{}, fmt.Errorf("%w: expected (entity of type `any_entity_type`), got %v", ErrType, TypeName(v))
 	}
 	return ev, nil
+}
+
+func ValueToDatetime(v types.Value) (types.Datetime, error) {
+	d, ok := v.(types.Datetime)
+	if !ok {
+		return types.Datetime{}, fmt.Errorf("%w: expected datetime, got %v", ErrType, TypeName(v))
+	}
+	return d, nil
 }
 
 func ValueToDecimal(v types.Value) (types.Decimal, error) {

--- a/internal/eval/util_test.go
+++ b/internal/eval/util_test.go
@@ -119,6 +119,26 @@ func TestUtil(t *testing.T) {
 
 	})
 
+	t.Run("Datetime", func(t *testing.T) {
+		t.Parallel()
+		t.Run("roundTrip", func(t *testing.T) {
+			t.Parallel()
+			dv, err := types.ParseDatetime("2024-07-15T09:00:00Z")
+			testutil.OK(t, err)
+			v, err := ValueToDatetime(dv)
+			testutil.OK(t, err)
+			testutil.FatalIf(t, !v.Equal(dv), "got %v want %v", v, dv)
+		})
+
+		t.Run("toDatetimeOnNonDatetime", func(t *testing.T) {
+			t.Parallel()
+			v, err := ValueToDatetime(types.Boolean(true))
+			testutil.ErrorIs(t, err, ErrType)
+			testutil.Equals(t, v, types.Datetime{})
+		})
+
+	})
+
 	t.Run("Decimal", func(t *testing.T) {
 		t.Parallel()
 		t.Run("roundTrip", func(t *testing.T) {
@@ -161,6 +181,7 @@ func TestTypeName(t *testing.T) {
 	}{
 
 		{"boolean", types.Boolean(true), "bool"},
+		{"datetime", types.UnsafeDatetime(42), "datetime"},
 		{"decimal", types.UnsafeDecimal(42), "decimal"},
 		{"entityUID", types.NewEntityUID("T", "42"), "(entity of type `T`)"},
 		{"ip", types.IPAddr{}, "IP"},

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -8,8 +8,9 @@ type extInfo struct {
 }
 
 var ExtMap = map[types.Path]extInfo{
-	"ip":      {Args: 1, IsMethod: false},
-	"decimal": {Args: 1, IsMethod: false},
+	"ip":       {Args: 1, IsMethod: false},
+	"decimal":  {Args: 1, IsMethod: false},
+	"datetime": {Args: 1, IsMethod: false},
 
 	"lessThan":           {Args: 2, IsMethod: true},
 	"lessThanOrEqual":    {Args: 2, IsMethod: true},
@@ -21,6 +22,8 @@ var ExtMap = map[types.Path]extInfo{
 	"isLoopback":  {Args: 1, IsMethod: true},
 	"isMulticast": {Args: 1, IsMethod: true},
 	"isInRange":   {Args: 2, IsMethod: true},
+
+	"toDate": {Args: 1, IsMethod: true},
 }
 
 func init() {

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestExtensions(t *testing.T) {
 	t.Parallel()
-	testutil.Equals(t, len(ExtMap), 11)
+	testutil.Equals(t, len(ExtMap), 13)
 }

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -128,6 +128,6 @@ type nodeJSON struct {
 	// Record
 	Record recordJSON `json:"Record,omitempty"`
 
-	// Any other method: decimal, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
+	// Any other method: decimal, datetime, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
 	ExtensionCall extensionJSON `json:"-"`
 }

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -171,7 +171,6 @@ func ParseDatetime(s string) (Datetime, error) {
 		}
 	}
 
-	fmt.Printf("WE'RE HERE: %s\n", s[i:length])
 
 	if i >= length {
 		return Datetime{}, fmt.Errorf("%w: expected timezone indicator", ErrDatetime)

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -1,0 +1,267 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+type Datetime struct {
+	// Value is a timestamp in milliseconds
+	Value int64
+}
+
+func UnsafeDatetime[T int | int64 | float64](v T) Datetime {
+	return Datetime{Value: int64(v)}
+}
+
+func FromStdTime(t time.Time) Datetime {
+	return Datetime{Value: t.UnixMilli()}
+}
+
+// "YYYY-MM-DD" (date only)
+// "YYYY-MM-DDThh:mm:ssZ" (UTC)
+// "YYYY-MM-DDThh:mm:ss.SSSZ" (UTC with millisecond precision)
+// "YYYY-MM-DDThh:mm:ss(+/-)hhmm" (With timezone offset in hours and minutes)
+// "YYYY-MM-DDThh:mm:ss.SSS(+/-)hhmm" (With timezone offset in hours and minutes and millisecond precision)
+func ParseDatetime(s string) (Datetime, error) {
+	var (
+		year, month, day, hour, minute, second, milli int
+		offsetHour, offsetMinute                      time.Duration
+		i                                             int
+	)
+
+	length := len(s)
+
+	if length < 10 {
+		return Datetime{}, fmt.Errorf("%w: string too short", ErrDatetime)
+	}
+
+	// parse YYYY-MM-DD
+
+	// YYYY
+	if !(unicode.IsDigit(rune(s[0])) &&
+		unicode.IsDigit(rune(s[1])) &&
+		unicode.IsDigit(rune(s[2])) &&
+		unicode.IsDigit(rune(s[3]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid year", ErrDatetime)
+	}
+
+	year = 1000*int(rune(s[i])-'0') +
+		100*int(rune(s[i+1])-'0') +
+		10*int(rune(s[i+2])-'0') +
+		int(rune(s[i+3])-'0')
+
+	i = 4
+
+	c := rune(s[i])
+	if c != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// MM
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid month", ErrDatetime)
+	}
+
+	month = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// DD
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid day", ErrDatetime)
+	}
+
+	day = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	if i == length { // done.
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return Datetime{Value: t.UnixMilli()}, nil
+	}
+
+	if length < 20 { // can't possibly have a well formed time.
+		return Datetime{}, fmt.Errorf("%w: invalid time", ErrDatetime)
+	}
+
+	// expect 'T'
+	c = rune(s[i])
+	if c != 'T' {
+		return Datetime{}, fmt.Errorf("%w: expected 'T'", ErrDatetime)
+	}
+
+	i++
+
+	// hh
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid hour", ErrDatetime)
+	}
+
+	hour = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// mm
+
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid minute", ErrDatetime)
+	}
+
+	minute = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// ss
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid second", ErrDatetime)
+	}
+
+	second = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i += 2
+
+	// .SSS ??
+
+	c = rune(s[i])
+	if c == '.' {
+		i++
+		if i+3 <= length {
+			if !(unicode.IsDigit(rune(s[i])) &&
+				unicode.IsDigit(rune(s[i+1])) &&
+				unicode.IsDigit(rune(s[i+2]))) {
+				return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
+			}
+
+			milli = 100*int(rune(s[i])-'0') + 10*int(rune(s[i+1])-'0') + int(rune(s[i+2])-'0')
+			i = i + 3
+		} else {
+			return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
+		}
+	}
+
+	fmt.Printf("WE'RE HERE: %s\n", s[i:length])
+
+	if i >= length {
+		return Datetime{}, fmt.Errorf("%w: expected timezone indicator", ErrDatetime)
+	}
+
+	c = rune(s[i])
+	if c == 'Z' { // "YYYY-MM-DDThh:mm:ssZ"
+		if i+1 == length {
+			t := time.Date(year, time.Month(month),
+				day, hour, minute, second,
+				int(time.Duration(milli)*time.Millisecond), time.UTC)
+			return Datetime{Value: t.UnixMilli()}, nil
+		}
+		return Datetime{}, fmt.Errorf("%w: unexpected trailer after timezone indicator", ErrDatetime)
+	}
+
+	// It must have an offset. +/-hhmm
+
+	if i+5 > length {
+		return Datetime{}, fmt.Errorf("%w: expected time offset", ErrDatetime)
+	} else if i+5 < length {
+		return Datetime{}, fmt.Errorf("%w: unexpected trailer", ErrDatetime)
+	}
+
+	sign := time.Duration(1)
+	c = rune(s[i])
+	if c == '-' {
+		sign = -sign
+	} else if c != '+' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1])) &&
+		unicode.IsDigit(rune(s[i+2])) &&
+		unicode.IsDigit(rune(s[i+3]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid time offset", ErrDatetime)
+	}
+
+	offsetHour = time.Duration(10*int64(rune(s[i])-'0')+int64(rune(s[i+1])-'0')) * time.Hour
+	offsetMinute = time.Duration(10*int64(rune(s[i+2])-'0')+int64(rune(s[i+3])-'0')) * time.Minute
+
+	t := time.Date(year, time.Month(month), day,
+		hour, minute, second,
+		int(time.Duration(milli)*time.Millisecond), time.UTC)
+	t = t.Add(sign * (offsetHour + offsetMinute))
+	return Datetime{Value: t.UnixMilli()}, nil
+}
+
+func (a Datetime) Equal(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a == b
+}
+
+func (a Datetime) Less(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a.Value < b.Value
+}
+
+func (a Datetime) LessEqual(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a.Value <= b.Value
+}
+
+func (a Datetime) MarshalCedar() []byte {
+	return []byte(`datetime("` + a.String() + `")`)
+}
+
+func (a Datetime) String() string {
+	return time.UnixMilli(a.Value).UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+func (a Datetime) UnmarshalJSON(b []byte) error {
+	// TODO
+	return nil
+}
+
+func (a Datetime) MarshalJSON() ([]byte, error) {
+	return []byte(`datetime("` + a.String() + `")`), nil
+}
+
+func (a Datetime) ExplicitMarshalJSON() ([]byte, error) {
+	return json.Marshal(extValueJSON{
+		Extn: &extn{
+			Fn:  "datetime",
+			Arg: a.String(),
+		},
+	})
+}
+
+func (v Datetime) deepClone() Value { return v }

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -45,7 +45,6 @@ func TestDatetime(t *testing.T) {
 			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.out), func(t *testing.T) {
 				t.Parallel()
 				d, err := types.ParseDatetime(tt.in)
-				fmt.Println(d, d.Value)
 				testutil.OK(t, err)
 				testutil.Equals(t, d.String(), tt.out)
 			})

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -1,0 +1,124 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cedar-policy/cedar-go/internal/testutil"
+	"github.com/cedar-policy/cedar-go/types"
+)
+
+func TestDatetime(t *testing.T) {
+	t.Parallel()
+	{
+		tests := []struct{ in, out string }{
+			// date only YYYY-MM-DD
+			{"1970-01-01", "1970-01-01T00:00:00.000Z"},
+			{"1970-10-10", "1970-10-10T00:00:00.000Z"},
+			{"1970-11-11", "1970-11-11T00:00:00.000Z"},
+
+			// date and time only YYYY-MM-DDThh:mm:ssZ
+			{"1970-01-01T01:01:01Z", "1970-01-01T01:01:01.000Z"},
+			{"1970-01-01T10:10:10Z", "1970-01-01T10:10:10.000Z"},
+			{"1970-01-01T11:11:11Z", "1970-01-01T11:11:11.000Z"},
+
+			// date and time + milli only YYYY-MM-DDThh:mm:ss.SSSZ
+			{"1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T00:00:00.001Z", "1970-01-01T00:00:00.001Z"},
+			{"1970-01-01T00:00:00.011Z", "1970-01-01T00:00:00.011Z"},
+			{"1970-01-01T00:00:00.111Z", "1970-01-01T00:00:00.111Z"},
+			{"1970-01-01T00:00:00.010Z", "1970-01-01T00:00:00.010Z"},
+			{"1970-01-01T00:00:00.100Z", "1970-01-01T00:00:00.100Z"},
+
+			{"1970-01-01T00:00:00+0001", "1970-01-01T00:01:00.000Z"},
+			{"1970-01-01T00:00:00+0010", "1970-01-01T00:10:00.000Z"},
+			{"1970-01-01T00:00:00+0100", "1970-01-01T01:00:00.000Z"},
+			{"1970-01-01T00:00:00+1000", "1970-01-01T10:00:00.000Z"},
+
+			{"1970-01-01T00:01:00-0001", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T00:10:00-0010", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T01:00:00-0100", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T10:00:00-1000", "1970-01-01T00:00:00.000Z"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.out), func(t *testing.T) {
+				t.Parallel()
+				d, err := types.ParseDatetime(tt.in)
+				fmt.Println(d, d.Value)
+				testutil.OK(t, err)
+				testutil.Equals(t, d.String(), tt.out)
+			})
+		}
+	}
+
+	{
+		tests := []struct{ in, errStr string }{
+			{"", "error parsing datetime value: string too short"},
+			{"-", "error parsing datetime value: string too short"},
+			{"012345678", "error parsing datetime value: string too short"},
+
+			{"195-01-01T00:00:00Z", "error parsing datetime value: invalid year"},
+			{"1995-1-01T00:00:00Z", "error parsing datetime value: invalid month"},
+			{"1995-01-0T00:00:00Z", "error parsing datetime value: invalid day"},
+			{"1995-01T00:00:00Z", "error parsing datetime value: unexpected character 'T'"},
+			{"1995-01-01T:00:00Z", "error parsing datetime value: invalid time"},
+			{"1995-01-01Taa:00:00Z", "error parsing datetime value: invalid hour"},
+			{"1995-01-01T00:aa:00Z", "error parsing datetime value: invalid minute"},
+			{"1995-01-01T00:00:aaZ", "error parsing datetime value: invalid second"},
+			{"1995-01-01T00:00:00Zgarbage", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.0", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.00", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.aaa", "error parsing datetime value: invalid millisecond"},
+
+			{"1995-01-01T00:00:00.001", "error parsing datetime value: expected timezone indicator"},
+
+			{"1995-01-01T00:00:00.000Z+", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.000Z+0000", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.000Z+000", "error parsing datetime value: unexpected trailer after timezone indicator"},
+
+			{"1995-01-01T00:00:00.000+", "error parsing datetime value: expected time offset"},
+
+			{"1995-01-01T00:00:00.000+", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-", "error parsing datetime value: expected time offset"},
+
+			{"1995-01-01T00:00:00.000-0", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-00", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-000", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-000a", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-00aa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-0aaa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-aaaa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-aaaa0", "error parsing datetime value: unexpected trailer"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.errStr), func(t *testing.T) {
+				t.Parallel()
+				_, err := types.ParseDatetime(tt.in)
+				testutil.ErrorIs(t, err, types.ErrDatetime)
+				testutil.Equals(t, err.Error(), tt.errStr)
+			})
+		}
+	}
+
+	t.Run("Equal", func(t *testing.T) {
+		t.Parallel()
+		one := types.UnsafeDatetime(1)
+		one2 := types.UnsafeDatetime(1)
+		zero := types.UnsafeDatetime(0)
+		f := types.Boolean(false)
+		testutil.FatalIf(t, !one.Equal(one), "%v not Equal to %v", one, one)
+		testutil.FatalIf(t, !one.Equal(one2), "%v not Equal to %v", one, one2)
+		testutil.FatalIf(t, one.Equal(zero), "%v Equal to %v", one, zero)
+		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
+		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
+	})
+
+	t.Run("MarshalCedar", func(t *testing.T) {
+		t.Parallel()
+		testutil.Equals(t, string(types.UnsafeDatetime(42).MarshalCedar()), `datetime("1970-01-01T00:00:00.042Z")`)
+	})
+
+}

--- a/types/json.go
+++ b/types/json.go
@@ -68,6 +68,13 @@ func UnmarshalJSON(b []byte, v *Value) error {
 				}
 				*v = val
 				return nil
+			case "datetime":
+				val, err := ParseDatetime(res.Extn.Arg)
+				if err != nil {
+					return err
+				}
+				*v = val
+				return nil
 			default:
 				return errJSONInvalidExtn
 			}

--- a/types/long.go
+++ b/types/long.go
@@ -13,6 +13,16 @@ func (a Long) Equal(bi Value) bool {
 	return ok && a == b
 }
 
+func (a Long) Less(bi Value) bool {
+	b, ok := bi.(Long)
+	return ok && a < b
+}
+
+func (a Long) LessEqual(bi Value) bool {
+	b, ok := bi.(Long)
+	return ok && a <= b
+}
+
 // ExplicitMarshalJSON marshals the Long into JSON.
 func (v Long) ExplicitMarshalJSON() ([]byte, error) { return json.Marshal(v) }
 

--- a/types/value.go
+++ b/types/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+var ErrDatetime = fmt.Errorf("error parsing datetime value")
 var ErrDecimal = fmt.Errorf("error parsing decimal value")
 var ErrIP = fmt.Errorf("error parsing ip value")
 

--- a/types/virtual.go
+++ b/types/virtual.go
@@ -1,0 +1,7 @@
+package types
+
+type Lesser interface {
+	Value
+	Less(Value) bool
+	LessEqual(Value) bool
+}


### PR DESCRIPTION
See _pending_ [RFC 80](https://github.com/strongdm/cedar-rfcs/blob/datetime-rfc/text/0080-datetime-extension.md) for details.

This PR does not add the duration type, nor the methods `toTime()`, `offset()`, or `durationSince()` that would require it.

This PR adds operator overloading, by introducing a set of "Virtual" comparison Evaler. Types that can overload operators must implement the `Lesser` interface. Long and Datetime are implemented in this PR. (Note: It is expected that there will be a Decimal operator overload RFC at some later date, but that is not hooked into this)

The now obsolete Evalers for Long comparisons have not been removed. A possible improvement to this PR would be to utilize them when it is known that Longs are on the right and left side.

The datetime itself is backed by an int64, and can be lifted from a Go `time.Time`, integer or float "unsafely."




