### PR TITLE
Several improvements to the upstream corpus test workflow

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -3,14 +3,16 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
-  # push:
 
 jobs:
-  build:
+  Check-Upstream:
     defaults:
       run:
         shell: bash
     runs-on: ubuntu-latest
+    if: github.repository == 'cedar-policy/cedar-go'
+    permissions:
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -20,19 +22,33 @@ jobs:
 
       # cmp returns status code 1 if the files differ
       - name: Compare
+        id: compare
         run: cmp /tmp/corpus-tests.tar.gz corpus-tests.tar.gz
 
       - name: Notify on Failure
-        if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v6
+        if: failure() && steps.compare.outcome == 'failure'
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.create({
+            // Get a list of all open issues labeled with 'upstream-corpus-test'. The documentation for
+            // listForRepo states that it should only return open issues.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Upstream Integration Test Corpus Modified',
-              body: 'The upstream integration test corpus at https://raw.githubusercontent.com/cedar-policy/cedar-integration-tests/main/corpus-tests.tar.gz has been updated. Please integrate the changes into the local copy.'
-              assignees: ['jmccarthy', 'philhassey', 'patjakdev'],
-              labels: ['bug']
+              labels: 'upstream-corpus-test'
             })
+            .then((issues) => {
+              console.log(`Found ${issues.length} open issues`)
+              // If one doesn't exist, create it
+              if (issues.length === 0) {
+                github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: 'Upstream Integration Test Corpus Modified',
+                  body: 'The upstream integration test corpus at https://raw.githubusercontent.com/cedar-policy/cedar-integration-tests/main/corpus-tests.tar.gz has been updated. Please integrate the changes into the local copy.',
+                  assignees: ['jmccarthy', 'philhassey', 'patjakdev'],
+                  labels: ['upstream-corpus-test']
+                })
+              }
+            });


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

* Only run this workflow on the official cedar-go repo
* Update `actions/github-script` to @v7 to avoid warnings about using an old NodeJS version
* Only open an issue if the compare step failed. We don't necessarily want to open an issue if the `curl` fails for some reason.
* Give the job permission to create issues
* Only open an issue if an open one does not already exist

