### PR TITLE
Fix parsing of reserved keywords

### DIFF
--- a/internal/parser/cedar_tokenize.go
+++ b/internal/parser/cedar_tokenize.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -23,6 +24,7 @@ const (
 	TokenEOF = TokenType(iota)
 	TokenIdent
 	TokenInt
+	TokenReservedKeyword
 	TokenString
 	TokenOperator
 	TokenUnknown
@@ -33,6 +35,8 @@ type Token struct {
 	Pos  Position
 	Text string
 }
+
+var reservedKeywords = []string{"true", "false", "if", "then", "else", "in", "like", "has"}
 
 func (t Token) isEOF() bool {
 	return t.Type == TokenEOF
@@ -472,10 +476,16 @@ redo:
 	s.tokEnd = s.srcPos - s.lastCharLen
 	s.ch = ch
 
+	// last minute check for reserved keywords
+	text := s.tokenText()
+	if tt == TokenIdent && slices.Contains(reservedKeywords, text) {
+		tt = TokenReservedKeyword
+	}
+
 	return Token{
 		Type: tt,
 		Pos:  s.position,
-		Text: s.tokenText(),
+		Text: text,
 	}
 }
 

--- a/internal/parser/cedar_tokenize.go
+++ b/internal/parser/cedar_tokenize.go
@@ -36,7 +36,9 @@ type Token struct {
 	Text string
 }
 
-var reservedKeywords = []string{"true", "false", "if", "then", "else", "in", "like", "has"}
+// N.B. "is" is included here for compatibility with the Rust implementation. The Cedar specification does not list
+// "is" as a reserved keyword
+var reservedKeywords = []string{"true", "false", "if", "then", "else", "in", "like", "has", "is"}
 
 func (t Token) isEOF() bool {
 	return t.Type == TokenEOF

--- a/internal/parser/cedar_tokenize.go
+++ b/internal/parser/cedar_tokenize.go
@@ -52,6 +52,10 @@ func (t Token) isInt() bool {
 	return t.Type == TokenInt
 }
 
+func (t Token) isReservedKeyword() bool {
+	return t.Type == TokenReservedKeyword
+}
+
 func (t Token) isString() bool {
 	return t.Type == TokenString
 }

--- a/internal/parser/cedar_tokenize_test.go
+++ b/internal/parser/cedar_tokenize_test.go
@@ -27,7 +27,8 @@ These are some identifiers
 multiline comment
 // embedded comment does nothing
 */
-'/%|&=ë٩`
+'/%|&=ë٩
+true false if then else in like has`
 	want := []Token{
 		{Type: TokenIdent, Text: "These", Pos: Position{Offset: 1, Line: 2, Column: 1}},
 		{Type: TokenIdent, Text: "are", Pos: Position{Offset: 7, Line: 2, Column: 7}},
@@ -90,7 +91,16 @@ multiline comment
 		{Type: TokenUnknown, Text: "ë", Pos: Position{Offset: 271, Line: 16, Column: 7}},
 		{Type: TokenUnknown, Text: "٩", Pos: Position{Offset: 273, Line: 16, Column: 8}},
 
-		{Type: TokenEOF, Text: "", Pos: Position{Offset: 275, Line: 16, Column: 9}},
+		{Type: TokenReservedKeyword, Text: "true", Pos: Position{Offset: 276, Line: 17, Column: 1}},
+		{Type: TokenReservedKeyword, Text: "false", Pos: Position{Offset: 281, Line: 17, Column: 6}},
+		{Type: TokenReservedKeyword, Text: "if", Pos: Position{Offset: 287, Line: 17, Column: 12}},
+		{Type: TokenReservedKeyword, Text: "then", Pos: Position{Offset: 290, Line: 17, Column: 15}},
+		{Type: TokenReservedKeyword, Text: "else", Pos: Position{Offset: 295, Line: 17, Column: 20}},
+		{Type: TokenReservedKeyword, Text: "in", Pos: Position{Offset: 300, Line: 17, Column: 25}},
+		{Type: TokenReservedKeyword, Text: "like", Pos: Position{Offset: 303, Line: 17, Column: 28}},
+		{Type: TokenReservedKeyword, Text: "has", Pos: Position{Offset: 308, Line: 17, Column: 33}},
+
+		{Type: TokenEOF, Text: "", Pos: Position{Offset: 311, Line: 17, Column: 36}},
 	}
 	got, err := Tokenize([]byte(input))
 	testutil.OK(t, err)

--- a/internal/parser/cedar_tokenize_test.go
+++ b/internal/parser/cedar_tokenize_test.go
@@ -28,7 +28,7 @@ multiline comment
 // embedded comment does nothing
 */
 '/%|&=ë٩
-true false if then else in like has`
+true false if then else in like has is`
 	want := []Token{
 		{Type: TokenIdent, Text: "These", Pos: Position{Offset: 1, Line: 2, Column: 1}},
 		{Type: TokenIdent, Text: "are", Pos: Position{Offset: 7, Line: 2, Column: 7}},
@@ -99,8 +99,9 @@ true false if then else in like has`
 		{Type: TokenReservedKeyword, Text: "in", Pos: Position{Offset: 300, Line: 17, Column: 25}},
 		{Type: TokenReservedKeyword, Text: "like", Pos: Position{Offset: 303, Line: 17, Column: 28}},
 		{Type: TokenReservedKeyword, Text: "has", Pos: Position{Offset: 308, Line: 17, Column: 33}},
+		{Type: TokenReservedKeyword, Text: "is", Pos: Position{Offset: 312, Line: 17, Column: 37}},
 
-		{Type: TokenEOF, Text: "", Pos: Position{Offset: 311, Line: 17, Column: 36}},
+		{Type: TokenEOF, Text: "", Pos: Position{Offset: 314, Line: 17, Column: 39}},
 	}
 	got, err := Tokenize([]byte(input))
 	testutil.OK(t, err)

--- a/internal/parser/cedar_unmarshal.go
+++ b/internal/parser/cedar_unmarshal.go
@@ -704,16 +704,25 @@ func (p *parser) primary() (ast.Node, error) {
 		res = ast.True()
 	case t.Text == "false":
 		res = ast.False()
-	case t.Text == consts.Principal:
-		res = ast.Principal()
-	case t.Text == consts.Action:
-		res = ast.Action()
-	case t.Text == consts.Resource:
-		res = ast.Resource()
-	case t.Text == consts.Context:
-		res = ast.Context()
 	case t.isIdent():
-		return p.entityOrExtFun(t.Text)
+		// There's an ambiguity here between VAR, Entity, and ExtFun - all of which can start with an Ident. We need to
+		// look ahead one token to resolve it.
+		next := p.peek()
+		if next.Text == "::" || next.Text == "(" {
+			return p.entityOrExtFun(t.Text)
+		}
+		switch {
+		case t.Text == consts.Principal:
+			res = ast.Principal()
+		case t.Text == consts.Action:
+			res = ast.Action()
+		case t.Text == consts.Resource:
+			res = ast.Resource()
+		case t.Text == consts.Context:
+			res = ast.Context()
+		default:
+			return res, p.errorf("invalid primary")
+		}
 	case t.Text == "(":
 		expr, err := p.expression()
 		if err != nil {

--- a/internal/parser/cedar_unmarshal.go
+++ b/internal/parser/cedar_unmarshal.go
@@ -142,8 +142,11 @@ func (p *parser) annotations() (ast.Annotations, error) {
 func (p *parser) annotation(a *ast.Annotations, known map[string]struct{}) error {
 	var err error
 	t := p.advance()
-	if !t.isIdent() {
-		return p.errorf("expected ident")
+	// As of 2024-09-13, the ability to use reserved keywords is not documented in the Cedar schema. The ability to use
+	// reserved keywords was added in this commit:
+	// https://github.com/cedar-policy/cedar/commit/5f62c6df06b59abc5634d6668198a826839c6fb7
+	if !(t.isIdent() || t.isReservedKeyword()) {
+		return p.errorf("expected ident or reserved keyword")
 	}
 	name := t.Text
 	if err = p.exact("("); err != nil {

--- a/internal/parser/cedar_unmarshal.go
+++ b/internal/parser/cedar_unmarshal.go
@@ -843,7 +843,7 @@ func (p *parser) recordEntry() (string, ast.Node, error) {
 		}
 		key = str
 	default:
-		return key, value, p.errorf("unexpected token")
+		return "", ast.Node{}, p.errorf("expected ident or string")
 	}
 	if err := p.exact(":"); err != nil {
 		return key, value, err
@@ -862,7 +862,7 @@ func (p *parser) access(lhs ast.Node) (ast.Node, bool, error) {
 		p.advance()
 		t := p.advance()
 		if !t.isIdent() {
-			return ast.Node{}, false, p.errorf("unexpected token")
+			return ast.Node{}, false, p.errorf("expected ident")
 		}
 		if p.peek().Text == "(" {
 			methodName := t.Text

--- a/internal/parser/cedar_unmarshal_test.go
+++ b/internal/parser/cedar_unmarshal_test.go
@@ -553,6 +553,11 @@ func TestParseApproximateErrors(t *testing.T) {
 		{"func", `permit (principal, action, resource) when { ip(}`, "invalid primary"},
 		{"args", `permit (principal, action, resource) when { ip(42 42)`, "got 42 want ,"},
 		{"dupeKey", `permit (principal, action, resource) when { {k:42,k:43}`, "duplicate key"},
+		{"reservedKeywordAsRecordKey", `permit (principal, action, resource) when { {false:43} }`, "expected ident or string"},
+		{"reservedKeywordAsHas", `permit (principal, action, resource) when { {} has false }`, "expected ident or string"},
+		{"reservedKeywordAsEntityType", `permit (principal == false::"42", action, resource)`, "expected ident"},
+		{"reservedKeywordAsAttributeAccess", `permit (principal, action, resource) when { context.false }`, "expected ident"},
+		{"reservedKeywordAsAnnotation", `@false() permit (principal, action, resource)`, "expected ident"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -560,6 +565,7 @@ func TestParseApproximateErrors(t *testing.T) {
 			t.Parallel()
 			var pol parser.Policy
 			err := pol.UnmarshalCedar([]byte(tt.in))
+			testutil.Error(t, err)
 			testutil.FatalIf(t, !strings.Contains(err.Error(), tt.outErrSubstring), "got %v want %v", err.Error(), tt.outErrSubstring)
 		})
 	}

--- a/internal/parser/cedar_unmarshal_test.go
+++ b/internal/parser/cedar_unmarshal_test.go
@@ -71,6 +71,12 @@ permit ( principal, action, resource );`,
 			ast.Annotation("foo", "bar").Annotation("baz", "quux").Permit(),
 		},
 		{
+			"reserved keyword annotation key",
+			`@is("bar")
+permit ( principal, action, resource );`,
+			ast.Annotation("is", "bar").Permit(),
+		},
+		{
 			"scope eq",
 			`permit (
     principal == User::"johnny",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

This PR modifies the Cedar tokenizer to properly reserve the set of [reserved keywords](https://arc.net/l/quote/yvyhkfvf) from the Cedar spec. In addition, it resolves a parsing ambiguity for the `Primary` production, which requires a lookahead to determine whether it will be a `VAR`, `Entity`, or `ExtFun`.


