### PR TITLE
types: change Set() to take variadic arguments to match EntityUIDSet()

### DIFF
--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -249,9 +249,9 @@ func TestASTByTable(t *testing.T) {
 		},
 		{
 			"valueSet",
-			ast.Permit().When(ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43)}))),
+			ast.Permit().When(ast.Value(types.NewSet(types.Long(42), types.Long(43)))),
 			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
-				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeValue{Value: types.NewSet([]types.Value{types.Long(42), types.Long(43)})}}},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeValue{Value: types.NewSet(types.Long(42), types.Long(43))}}},
 			},
 		},
 		{

--- a/internal/eval/compile.go
+++ b/internal/eval/compile.go
@@ -74,7 +74,7 @@ func scopeToNode(varNode ast.NodeTypeVariable, in ast.IsScopeNode) ast.Node {
 		for i, e := range t.Entities {
 			vals[i] = e
 		}
-		return ast.NewNode(varNode).In(ast.Value(types.NewSet(vals)))
+		return ast.NewNode(varNode).In(ast.Value(types.NewSet(vals...)))
 	case ast.ScopeTypeIs:
 		return ast.NewNode(varNode).Is(t.Type)
 

--- a/internal/eval/compile_test.go
+++ b/internal/eval/compile_test.go
@@ -123,7 +123,7 @@ func TestScopeToNode(t *testing.T) {
 			"inSet",
 			ast.NewActionNode(),
 			ast.ScopeTypeInSet{Entities: []types.EntityUID{types.NewEntityUID("T", "42")}},
-			ast.Action().In(ast.Value(types.NewSet([]types.Value{types.NewEntityUID("T", "42")}))),
+			ast.Action().In(ast.Value(types.NewSet(types.NewEntityUID("T", "42")))),
 		},
 		{
 			"is",

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -69,7 +69,7 @@ func TestToEval(t *testing.T) {
 		{
 			"set",
 			ast.Set(ast.Long(42)),
-			types.NewSet([]types.Value{types.Long(42)}),
+			types.NewSet(types.Long(42)),
 			testutil.OK,
 		},
 		{
@@ -182,19 +182,19 @@ func TestToEval(t *testing.T) {
 		},
 		{
 			"contains",
-			ast.Value(types.NewSet([]types.Value{types.Long(42)})).Contains(ast.Long(42)),
+			ast.Value(types.NewSet(types.Long(42))).Contains(ast.Long(42)),
 			types.True,
 			testutil.OK,
 		},
 		{
 			"containsAll",
-			ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43), types.Long(44)})).ContainsAll(ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43)}))),
+			ast.Value(types.NewSet(types.Long(42), types.Long(43), types.Long(44))).ContainsAll(ast.Value(types.NewSet(types.Long(42), types.Long(43)))),
 			types.True,
 			testutil.OK,
 		},
 		{
 			"containsAny",
-			ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43), types.Long(44)})).ContainsAny(ast.Value(types.NewSet([]types.Value{types.Long(1), types.Long(42)}))),
+			ast.Value(types.NewSet(types.Long(42), types.Long(43), types.Long(44))).ContainsAny(ast.Value(types.NewSet(types.Long(1), types.Long(42)))),
 			types.True,
 			testutil.OK,
 		},

--- a/internal/eval/evalers.go
+++ b/internal/eval/evalers.go
@@ -721,7 +721,7 @@ func (n *setLiteralEval) Eval(env Env) (types.Value, error) {
 		}
 		vals[i] = v
 	}
-	return types.NewSet(vals), nil
+	return types.NewSet(vals...), nil
 }
 
 // containsEval

--- a/internal/eval/evalers_test.go
+++ b/internal/eval/evalers_test.go
@@ -1290,20 +1290,20 @@ func TestSetLiteralNode(t *testing.T) {
 		{"nested",
 			[]Evaler{
 				newLiteralEval(types.True),
-				newLiteralEval(types.NewSet([]types.Value{
+				newLiteralEval(types.NewSet(
 					types.False,
 					types.Long(1),
-				})),
+				)),
 				newLiteralEval(types.Long(10)),
 			},
-			types.NewSet([]types.Value{
+			types.NewSet(
 				types.True,
-				types.NewSet([]types.Value{
+				types.NewSet(
 					types.False,
 					types.Long(1),
-				}),
+				),
 				types.Long(10),
-			}),
+			),
 			nil},
 	}
 	for _, tt := range tests {
@@ -1343,8 +1343,8 @@ func TestContainsNode(t *testing.T) {
 	}
 	{
 		empty := types.Set{}
-		trueAndOne := types.NewSet([]types.Value{types.True, types.Long(1)})
-		nested := types.NewSet([]types.Value{trueAndOne, types.False, types.Long(2)})
+		trueAndOne := types.NewSet(types.True, types.Long(1))
+		nested := types.NewSet(trueAndOne, types.False, types.Long(2))
 
 		tests := []struct {
 			name     string
@@ -1398,9 +1398,9 @@ func TestContainsAllNode(t *testing.T) {
 	}
 	{
 		empty := types.Set{}
-		trueOnly := types.NewSet([]types.Value{types.True})
-		trueAndOne := types.NewSet([]types.Value{types.True, types.Long(1)})
-		nested := types.NewSet([]types.Value{trueAndOne, types.False, types.Long(2)})
+		trueOnly := types.NewSet(types.True)
+		trueAndOne := types.NewSet(types.True, types.Long(1))
+		nested := types.NewSet(trueAndOne, types.False, types.Long(2))
 
 		tests := []struct {
 			name     string
@@ -1452,10 +1452,10 @@ func TestContainsAnyNode(t *testing.T) {
 	}
 	{
 		empty := types.Set{}
-		trueOnly := types.NewSet([]types.Value{types.True})
-		trueAndOne := types.NewSet([]types.Value{types.True, types.Long(1)})
-		trueAndTwo := types.NewSet([]types.Value{types.True, types.Long(2)})
-		nested := types.NewSet([]types.Value{trueAndOne, types.False, types.Long(2)})
+		trueOnly := types.NewSet(types.True)
+		trueAndOne := types.NewSet(types.True, types.Long(1))
+		trueAndTwo := types.NewSet(types.True, types.Long(2))
+		nested := types.NewSet(trueAndOne, types.False, types.Long(2))
 
 		tests := []struct {
 			name     string
@@ -1495,7 +1495,7 @@ func TestContainsAnyNode(t *testing.T) {
 			set2[i] = types.Long(setSize + i)
 		}
 
-		n := newContainsAnyEval(newLiteralEval(types.NewSet(set1)), newLiteralEval(types.NewSet(set2)))
+		n := newContainsAnyEval(newLiteralEval(types.NewSet(set1...)), newLiteralEval(types.NewSet(set2...)))
 
 		// This call would take several minutes if the evaluation of ContainsAny was quadratic
 		val, err := n.Eval(Env{})
@@ -1954,9 +1954,9 @@ func TestInNode(t *testing.T) {
 		{
 			"RhsTypeError2",
 			newLiteralEval(types.NewEntityUID("human", "joe")),
-			newLiteralEval(types.NewSet([]types.Value{
+			newLiteralEval(types.NewSet(
 				types.String("foo"),
-			})),
+			)),
 			map[string][]string{},
 			zeroValue(),
 			ErrType,
@@ -1972,9 +1972,9 @@ func TestInNode(t *testing.T) {
 		{
 			"Reflexive2",
 			newLiteralEval(types.NewEntityUID("human", "joe")),
-			newLiteralEval(types.NewSet([]types.Value{
+			newLiteralEval(types.NewSet(
 				types.NewEntityUID("human", "joe"),
-			})),
+			)),
 			map[string][]string{},
 			types.True,
 			nil,
@@ -2078,9 +2078,9 @@ func TestIsInNode(t *testing.T) {
 			"RhsTypeError2",
 			newLiteralEval(types.NewEntityUID("human", "joe")),
 			"human",
-			newLiteralEval(types.NewSet([]types.Value{
+			newLiteralEval(types.NewSet(
 				types.String("foo"),
-			})),
+			)),
 			map[string][]string{},
 			zeroValue(),
 			ErrType,
@@ -2098,9 +2098,9 @@ func TestIsInNode(t *testing.T) {
 			"Reflexive2",
 			newLiteralEval(types.NewEntityUID("human", "joe")),
 			"human",
-			newLiteralEval(types.NewSet([]types.Value{
+			newLiteralEval(types.NewSet(
 				types.NewEntityUID("human", "joe"),
-			})),
+			)),
 			map[string][]string{},
 			types.True,
 			nil,
@@ -2307,7 +2307,7 @@ func TestCedarString(t *testing.T) {
 		{"number", types.Long(42), `42`, `42`},
 		{"bool", types.True, `true`, `true`},
 		{"record", types.NewRecord(types.RecordMap{"a": types.Long(42), "b": types.Long(43)}), `{"a":42, "b":43}`, `{"a":42, "b":43}`},
-		{"set", types.NewSet([]types.Value{types.Long(42), types.Long(43)}), `[42, 43]`, `[42, 43]`},
+		{"set", types.NewSet(types.Long(42), types.Long(43)), `[42, 43]`, `[42, 43]`},
 		{"singleIP", types.IPAddr(netip.MustParsePrefix("192.168.0.42/32")), `192.168.0.42`, `ip("192.168.0.42")`},
 		{"ipPrefix", types.IPAddr(netip.MustParsePrefix("192.168.0.42/24")), `192.168.0.42/24`, `ip("192.168.0.42/24")`},
 		{"decimal", testutil.Must(types.NewDecimal(12345678, -4)), `1234.5678`, `decimal("1234.5678")`},

--- a/internal/eval/fold_test.go
+++ b/internal/eval/fold_test.go
@@ -21,7 +21,7 @@ func TestFoldNode(t *testing.T) {
 		},
 		{"set-bake",
 			ast.Set(ast.True()),
-			ast.Value(types.NewSet([]types.Value{types.True})),
+			ast.Value(types.NewSet(types.True)),
 		},
 		{"record-fold",
 			ast.Record(ast.Pairs{{Key: "key", Value: ast.Long(6).Multiply(ast.Long(7))}}),
@@ -29,7 +29,7 @@ func TestFoldNode(t *testing.T) {
 		},
 		{"set-fold",
 			ast.Set(ast.Long(6).Multiply(ast.Long(7))),
-			ast.Value(types.NewSet([]types.Value{types.Long(42)})),
+			ast.Value(types.NewSet(types.Long(42))),
 		},
 		{"record-blocked",
 			ast.Record(ast.Pairs{{Key: "key", Value: ast.Long(6).Multiply(ast.Context())}}),
@@ -205,7 +205,7 @@ func TestFoldPolicy(t *testing.T) {
 		{
 			"valueSetNodes",
 			ast.Permit().When(ast.Set(ast.Long(42), ast.Long(43))),
-			ast.Permit().When(ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43)}))),
+			ast.Permit().When(ast.Value(types.NewSet(types.Long(42), types.Long(43)))),
 		},
 		{
 			"valueRecordElements",

--- a/internal/eval/partial_test.go
+++ b/internal/eval/partial_test.go
@@ -718,7 +718,7 @@ func TestPartialBasic(t *testing.T) {
 		{
 			"valueSetNodesFold",
 			ast.Set(ast.Long(42), ast.Long(43)),
-			ast.Value(types.NewSet([]types.Value{types.Long(42), types.Long(43)})),
+			ast.Value(types.NewSet(types.Long(42), types.Long(43))),
 			testutil.OK,
 		},
 		{
@@ -1102,7 +1102,7 @@ func TestPartialBasic(t *testing.T) {
 		{
 			"opContainsKeep",
 			ast.Set(ast.Long(42)).Contains(ast.Context()),
-			ast.Value(types.NewSet([]types.Value{types.Long(42)})).Contains(ast.Context()),
+			ast.Value(types.NewSet(types.Long(42))).Contains(ast.Context()),
 			testutil.OK,
 		},
 		{
@@ -1120,7 +1120,7 @@ func TestPartialBasic(t *testing.T) {
 		{
 			"opContainsAllKeep",
 			ast.Set(ast.Long(42)).ContainsAll(ast.Context()),
-			ast.Value(types.NewSet([]types.Value{types.Long(42)})).ContainsAll(ast.Context()),
+			ast.Value(types.NewSet(types.Long(42))).ContainsAll(ast.Context()),
 			testutil.OK,
 		},
 		{
@@ -1138,7 +1138,7 @@ func TestPartialBasic(t *testing.T) {
 		{
 			"opContainsAnyKeep",
 			ast.Set(ast.Long(42)).ContainsAny(ast.Context()),
-			ast.Value(types.NewSet([]types.Value{types.Long(42)})).ContainsAny(ast.Context()),
+			ast.Value(types.NewSet(types.Long(42))).ContainsAny(ast.Context()),
 			testutil.OK,
 		},
 		{

--- a/internal/eval/util_test.go
+++ b/internal/eval/util_test.go
@@ -65,7 +65,7 @@ func TestUtil(t *testing.T) {
 		t.Parallel()
 		t.Run("roundTrip", func(t *testing.T) {
 			t.Parallel()
-			v := types.NewSet([]types.Value{types.Boolean(true), types.Long(1)})
+			v := types.NewSet(types.Boolean(true), types.Long(1))
 			slice, err := ValueToSet(v)
 			testutil.OK(t, err)
 			v2 := slice

--- a/types.go
+++ b/types.go
@@ -102,9 +102,9 @@ func NewRecord(r RecordMap) Record {
 	return types.NewRecord(r)
 }
 
-// NewSet returns an immutable Set given a Go slice of Values. Duplicates are removed and order is not preserved.
-func NewSet(s []types.Value) Set {
-	return types.NewSet(s)
+// NewSet returns an immutable Set given a variadic set of Values. Duplicates are removed and order is not preserved.
+func NewSet(s ...types.Value) Set {
+	return types.NewSet(s...)
 }
 
 // NewDecimal returns a Decimal value of i * 10^exponent.

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -66,7 +66,7 @@ func TestJSON_Value(t *testing.T) {
 		{"badDecimal", `{ "__extn": { "fn": "decimal", "arg": "bad" } }`, zeroValue(), ErrDecimal},
 		{"badDatetime", `{ "__extn": { "fn": "datetime", "arg": "bad" } }`, zeroValue(), ErrDatetime},
 		{"badDuration", `{ "__extn": { "fn": "duration", "arg": "bad" } }`, zeroValue(), ErrDuration},
-		{"set", `[42]`, NewSet([]Value{Long(42)}), nil},
+		{"set", `[42]`, NewSet(Long(42)), nil},
 		{"record", `{"a":"b"}`, NewRecord(RecordMap{"a": String("b")}), nil},
 		{"bool", `false`, Boolean(false), nil},
 	}
@@ -556,11 +556,11 @@ func TestJSONMarshal(t *testing.T) {
 		},
 		{
 			"set",
-			NewSet([]Value{
+			NewSet(
 				String("av"),
 				String("cv"),
 				String("bv"),
-			}),
+			),
 			`["cv","bv","av"]`,
 		},
 		{
@@ -608,7 +608,7 @@ func TestJSONSet(t *testing.T) {
 	})
 	t.Run("MarshalErr", func(t *testing.T) {
 		t.Parallel()
-		s := NewSet([]Value{&jsonErr{}})
+		s := NewSet(&jsonErr{})
 		_, err := json.Marshal(s)
 		testutil.Error(t, err)
 	})

--- a/types/set.go
+++ b/types/set.go
@@ -14,8 +14,8 @@ type Set struct {
 	hashVal uint64
 }
 
-// NewSet returns an immutable Set given a Go slice of Values. Duplicates are removed and order is not preserved.
-func NewSet(v []Value) Set {
+// NewSet returns an immutable Set given a variadic set of Values. Duplicates are removed and order is not preserved.
+func NewSet(v ...Value) Set {
 	var set map[uint64]Value
 	if v != nil {
 		set = make(map[uint64]Value, len(v))
@@ -125,7 +125,7 @@ func (v *Set) UnmarshalJSON(b []byte) error {
 		vals[i] = vv.Value
 	}
 
-	*v = NewSet(vals)
+	*v = NewSet(vals...)
 	return nil
 }
 

--- a/types/set_internal_test.go
+++ b/types/set_internal_test.go
@@ -17,7 +17,7 @@ func (c colliderValue) MarshalCedar() []byte { return nil }
 func (c colliderValue) Equal(v Value) bool   { return v.Equal(c.Value) }
 func (c colliderValue) hash() uint64         { return c.HashVal }
 
-func TestSet(t *testing.T) {
+func TestSetInternal(t *testing.T) {
 	t.Parallel()
 
 	t.Run("hash", func(t *testing.T) {
@@ -25,8 +25,8 @@ func TestSet(t *testing.T) {
 
 		t.Run("order independent", func(t *testing.T) {
 			t.Parallel()
-			s1 := NewSet([]Value{Long(42), Long(1337)})
-			s2 := NewSet([]Value{Long(1337), Long(42)})
+			s1 := NewSet(Long(42), Long(1337))
+			s2 := NewSet(Long(1337), Long(42))
 			testutil.Equals(t, s1.hash(), s2.hash())
 		})
 
@@ -38,12 +38,12 @@ func TestSet(t *testing.T) {
 			v3 := colliderValue{Value: String("baz"), HashVal: 1337}
 
 			permutations := []Set{
-				NewSet([]Value{v1, v2, v3}),
-				NewSet([]Value{v1, v3, v2}),
-				NewSet([]Value{v2, v1, v3}),
-				NewSet([]Value{v2, v3, v1}),
-				NewSet([]Value{v3, v1, v2}),
-				NewSet([]Value{v3, v2, v1}),
+				NewSet(v1, v2, v3),
+				NewSet(v1, v3, v2),
+				NewSet(v2, v1, v3),
+				NewSet(v2, v3, v1),
+				NewSet(v3, v1, v2),
+				NewSet(v3, v2, v1),
 			}
 			expected := permutations[0].hash()
 			for _, p := range permutations {
@@ -59,12 +59,12 @@ func TestSet(t *testing.T) {
 			v3 := colliderValue{Value: String("baz"), HashVal: 1337}
 
 			permutations := []Set{
-				NewSet([]Value{v1, v2, v3}),
-				NewSet([]Value{v1, v3, v2}),
-				NewSet([]Value{v2, v1, v3}),
-				NewSet([]Value{v2, v3, v1}),
-				NewSet([]Value{v3, v1, v2}),
-				NewSet([]Value{v3, v2, v1}),
+				NewSet(v1, v2, v3),
+				NewSet(v1, v3, v2),
+				NewSet(v2, v1, v3),
+				NewSet(v2, v3, v1),
+				NewSet(v3, v1, v2),
+				NewSet(v3, v2, v1),
 			}
 			expected := permutations[0].hash()
 			for _, p := range permutations {
@@ -74,18 +74,16 @@ func TestSet(t *testing.T) {
 
 		t.Run("duplicates unimportant", func(t *testing.T) {
 			t.Parallel()
-			s1 := NewSet([]Value{Long(42), Long(1337)})
-			s2 := NewSet([]Value{Long(42), Long(1337), Long(1337)})
+			s1 := NewSet(Long(42), Long(1337))
+			s2 := NewSet(Long(42), Long(1337), Long(1337))
 			testutil.Equals(t, s1.hash(), s2.hash())
 		})
 
 		t.Run("empty set", func(t *testing.T) {
 			t.Parallel()
 			m1 := Set{}
-			m2 := NewSet([]Value{})
-			m3 := NewSet(nil)
+			m2 := NewSet()
 			testutil.Equals(t, m1.hash(), m2.hash())
-			testutil.Equals(t, m2.hash(), m3.hash())
 		})
 
 		// These tests don't necessarily hold for all values of Set, but we want to ensure we are considering
@@ -93,15 +91,15 @@ func TestSet(t *testing.T) {
 
 		t.Run("extra element", func(t *testing.T) {
 			t.Parallel()
-			s1 := NewSet([]Value{Long(42), Long(1337)})
-			s2 := NewSet([]Value{Long(42), Long(1337), Long(1)})
+			s1 := NewSet(Long(42), Long(1337))
+			s2 := NewSet(Long(42), Long(1337), Long(1))
 			testutil.FatalIf(t, s1.hash() == s2.hash(), "unexpected hash collision")
 		})
 
 		t.Run("disjoint", func(t *testing.T) {
 			t.Parallel()
-			s1 := NewSet([]Value{Long(42), Long(1337)})
-			s2 := NewSet([]Value{Long(0), String("hi")})
+			s1 := NewSet(Long(42), Long(1337))
+			s2 := NewSet(Long(0), String("hi"))
 			testutil.FatalIf(t, s1.hash() == s2.hash(), "unexpected hash collision")
 		})
 	})
@@ -114,7 +112,7 @@ func TestSet(t *testing.T) {
 		v3 := colliderValue{Value: String("baz"), HashVal: 1338}
 		v4 := colliderValue{Value: String("baz"), HashVal: 1337}
 
-		set := NewSet([]Value{v1, v2, v3, v4})
+		set := NewSet(v1, v2, v3, v4)
 
 		testutil.Equals(t, set.Len(), 3)
 

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -15,22 +15,24 @@ func TestSet(t *testing.T) {
 		t.Parallel()
 		empty := types.Set{}
 		empty2 := types.Set{}
-		oneTrue := types.NewSet([]types.Value{types.Boolean(true)})
-		oneTrue2 := types.NewSet([]types.Value{types.Boolean(true)})
-		oneFalse := types.NewSet([]types.Value{types.Boolean(false)})
-		nestedOnce := types.NewSet([]types.Value{empty, oneTrue, oneFalse})
-		nestedOnce2 := types.NewSet([]types.Value{empty, oneTrue, oneFalse})
-		nestedTwice := types.NewSet([]types.Value{empty, oneTrue, oneFalse, nestedOnce})
-		nestedTwice2 := types.NewSet([]types.Value{empty, oneTrue, oneFalse, nestedOnce})
-		oneTwoThree := types.NewSet([]types.Value{
+		empty3 := types.NewSet()
+		oneTrue := types.NewSet(types.Boolean(true))
+		oneTrue2 := types.NewSet(types.Boolean(true))
+		oneFalse := types.NewSet(types.Boolean(false))
+		nestedOnce := types.NewSet(empty, oneTrue, oneFalse)
+		nestedOnce2 := types.NewSet(empty, oneTrue, oneFalse)
+		nestedTwice := types.NewSet(empty, oneTrue, oneFalse, nestedOnce)
+		nestedTwice2 := types.NewSet(empty, oneTrue, oneFalse, nestedOnce)
+		oneTwoThree := types.NewSet(
 			types.Long(1), types.Long(2), types.Long(3),
-		})
-		threeTwoTwoOne := types.NewSet([]types.Value{
+		)
+		threeTwoTwoOne := types.NewSet(
 			types.Long(3), types.Long(2), types.Long(2), types.Long(1),
-		})
+		)
 
 		testutil.FatalIf(t, !empty.Equal(empty), "%v not Equal to %v", empty, empty)
 		testutil.FatalIf(t, !empty.Equal(empty2), "%v not Equal to %v", empty, empty2)
+		testutil.FatalIf(t, !empty.Equal(empty3), "%v not Equal to %v", empty, empty3)
 		testutil.FatalIf(t, !oneTrue.Equal(oneTrue), "%v not Equal to %v", oneTrue, oneTrue)
 		testutil.FatalIf(t, !oneTrue.Equal(oneTrue2), "%v not Equal to %v", oneTrue, oneTrue2)
 		testutil.FatalIf(t, !nestedOnce.Equal(nestedOnce), "%v not Equal to %v", nestedOnce, nestedOnce)
@@ -49,7 +51,7 @@ func TestSet(t *testing.T) {
 		testutil.Equals(t, types.Set{}.String(), "[]")
 		testutil.Equals(
 			t,
-			types.NewSet([]types.Value{types.Boolean(true), types.Long(1)}).String(),
+			types.NewSet(types.Boolean(true), types.Long(1)).String(),
 			"[true, 1]")
 	})
 
@@ -57,8 +59,8 @@ func TestSet(t *testing.T) {
 		t.Parallel()
 		testutil.Equals(t, types.Set{}.Len(), 0)
 		testutil.Equals(t, types.Set{}.Len(), 0)
-		testutil.Equals(t, types.NewSet([]types.Value{types.Long(1)}).Len(), 1)
-		testutil.Equals(t, types.NewSet([]types.Value{types.Long(1), types.Long(2)}).Len(), 2)
+		testutil.Equals(t, types.NewSet(types.Long(1)).Len(), 1)
+		testutil.Equals(t, types.NewSet(types.Long(1), types.Long(2)).Len(), 2)
 	})
 
 	t.Run("IterateEntire", func(t *testing.T) {
@@ -76,7 +78,7 @@ func TestSet(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
-				set := types.NewSet(tt.values)
+				set := types.NewSet(tt.values...)
 
 				var got []types.Value
 				set.Iterate(func(v types.Value) bool {
@@ -99,7 +101,7 @@ func TestSet(t *testing.T) {
 	t.Run("IteratePartial", func(t *testing.T) {
 		t.Parallel()
 
-		set := types.NewSet([]types.Value{types.Long(42), types.Long(1337)})
+		set := types.NewSet(types.Long(42), types.Long(1337))
 
 		// It would be nice to know which element or elements were returned when iteration ends early, but iteration
 		// order for Sets is non-deterministic
@@ -140,30 +142,27 @@ func TestSet(t *testing.T) {
 		s := types.Set{}.Slice()
 		testutil.Equals(t, s, nil)
 
-		s = types.NewSet(nil).Slice()
+		s = types.NewSet().Slice()
 		testutil.Equals(t, s, nil)
 
-		s = types.NewSet([]types.Value{}).Slice()
-		testutil.Equals(t, s, []types.Value{})
-
-		s = types.NewSet([]types.Value{types.True}).Slice()
+		s = types.NewSet(types.True).Slice()
 		testutil.Equals(t, s, []types.Value{types.True})
 
-		s = types.NewSet([]types.Value{types.True, types.False}).Slice()
+		s = types.NewSet(types.True, types.False).Slice()
 		testutil.Equals(t, len(s), 2)
 		testutil.FatalIf(t, !slices.ContainsFunc(s, func(v types.Value) bool { return v.Equal(types.True) }), "")
 		testutil.FatalIf(t, !slices.ContainsFunc(s, func(v types.Value) bool { return v.Equal(types.False) }), "")
 
-		s = types.NewSet([]types.Value{types.True, types.False, types.True}).Slice()
+		s = types.NewSet(types.True, types.False, types.True).Slice()
 		testutil.Equals(t, len(s), 2)
 		testutil.FatalIf(t, !slices.ContainsFunc(s, func(v types.Value) bool { return v.Equal(types.True) }), "")
 		testutil.FatalIf(t, !slices.ContainsFunc(s, func(v types.Value) bool { return v.Equal(types.False) }), "")
 
 		// Show that mutating the returned slice doesn't affect Set's internal state
-		r := types.NewSet([]types.Value{types.True, types.False})
+		r := types.NewSet(types.True, types.False)
 		s = r.Slice()
 		_ = append(s, types.Long(0))
-		testutil.Equals(t, r, types.NewSet([]types.Value{types.True, types.False}))
+		testutil.Equals(t, r, types.NewSet(types.True, types.False))
 	})
 
 	// This test is intended to show the NewSet makes a copy of the Values in the input slice
@@ -173,7 +172,7 @@ func TestSet(t *testing.T) {
 		slice := []types.Value{types.Long(42)}
 		p := &slice[0]
 
-		set := types.NewSet(slice)
+		set := types.NewSet(slice...)
 
 		*p = types.Long(1337)
 
@@ -193,7 +192,7 @@ func TestSet(t *testing.T) {
 	t.Run("no duplicates", func(t *testing.T) {
 		t.Parallel()
 
-		set := types.NewSet([]types.Value{types.Long(42), types.Long(42)})
+		set := types.NewSet(types.Long(42), types.Long(42))
 
 		testutil.Equals(t, set.Len(), 1)
 

--- a/x/exp/batch/batch.go
+++ b/x/exp/batch/batch.go
@@ -377,7 +377,7 @@ func cloneSub(r types.Value, k types.String, v types.Value) (types.Value, bool) 
 			return true
 		})
 
-		return types.NewSet(newSlice), true
+		return types.NewSet(newSlice...), true
 	}
 	return r, false
 }

--- a/x/exp/batch/batch_test.go
+++ b/x/exp/batch/batch_test.go
@@ -634,8 +634,8 @@ func TestCloneSub(t *testing.T) {
 		},
 		{
 			"set",
-			types.NewSet([]types.Value{Variable("bananas")}), "bananas", types.String("hello"),
-			types.NewSet([]types.Value{types.String("hello")}), true,
+			types.NewSet(Variable("bananas")), "bananas", types.String("hello"),
+			types.NewSet(types.String("hello")), true,
 		},
 		{
 			"recordNoChange",
@@ -644,8 +644,8 @@ func TestCloneSub(t *testing.T) {
 		},
 		{
 			"setNoChange",
-			types.NewSet([]types.Value{Variable("asdf")}), "bananas", types.String("hello"),
-			types.NewSet([]types.Value{Variable("asdf")}), false,
+			types.NewSet(Variable("asdf")), "bananas", types.String("hello"),
+			types.NewSet(Variable("asdf")), false,
 		},
 	}
 	for _, tt := range tests {
@@ -667,10 +667,10 @@ func TestFindVariables(t *testing.T) {
 		out  []types.String
 	}{
 		{"record", types.NewRecord(types.RecordMap{"key": Variable("bananas")}), []types.String{"bananas"}},
-		{"set", types.NewSet([]types.Value{Variable("bananas")}), []types.String{"bananas"}},
-		{"dupes", types.NewSet([]types.Value{Variable("bananas"), Variable("bananas")}), []types.String{"bananas"}},
+		{"set", types.NewSet(Variable("bananas")), []types.String{"bananas"}},
+		{"dupes", types.NewSet(Variable("bananas"), Variable("bananas")), []types.String{"bananas"}},
 		{"none", types.String("test"), nil},
-		{"multi", types.NewSet([]types.Value{Variable("bananas"), Variable("test")}), []types.String{"bananas", "test"}},
+		{"multi", types.NewSet(Variable("bananas"), Variable("test")), []types.String{"bananas", "test"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In addition to making the two functions have a similar shape, this also cuts down quite a bit on the annoying `[]types.Value{}` wrapper detritus that we have to put around literal arguments.

