### PR TITLE
ast: Add AST builder methods for datetime-related types and operators

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -3,6 +3,7 @@ package ast_test
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/ast"
 	internalast "github.com/cedar-policy/cedar-go/internal/ast"
@@ -402,6 +403,51 @@ func TestASTByTable(t *testing.T) {
 			"opIsInRange",
 			ast.Permit().When(ast.Long(42).IsInRange(ast.Long(43))),
 			internalast.Permit().When(internalast.Long(42).IsInRange(internalast.Long(43))),
+		},
+		{
+			"opOffset",
+			ast.Permit().When(ast.Datetime(time.Time{}).Offset(ast.Duration(time.Duration(100)))),
+			internalast.Permit().When(internalast.Datetime(time.Time{}).Offset(internalast.Duration(time.Duration(100)))),
+		},
+		{
+			"opDurationSince",
+			ast.Permit().When(ast.Datetime(time.Time{}).DurationSince(ast.Datetime(time.Time{}))),
+			internalast.Permit().When(internalast.Datetime(time.Time{}).DurationSince(internalast.Datetime(time.Time{}))),
+		},
+		{
+			"opToDate",
+			ast.Permit().When(ast.Datetime(time.Time{}).ToDate()),
+			internalast.Permit().When(internalast.Datetime(time.Time{}).ToDate()),
+		},
+		{
+			"opToTime",
+			ast.Permit().When(ast.Datetime(time.Time{}).ToTime()),
+			internalast.Permit().When(internalast.Datetime(time.Time{}).ToTime()),
+		},
+		{
+			"opToDays",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToDays()),
+			internalast.Permit().When(internalast.Duration(100).ToDays()),
+		},
+		{
+			"opToHours",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToHours()),
+			internalast.Permit().When(internalast.Duration(100).ToHours()),
+		},
+		{
+			"opToMinutes",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToMinutes()),
+			internalast.Permit().When(internalast.Duration(100).ToMinutes()),
+		},
+		{
+			"opToSeconds",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToSeconds()),
+			internalast.Permit().When(internalast.Duration(100).ToSeconds()),
+		},
+		{
+			"opToMilliseconds",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToMilliseconds()),
+			internalast.Permit().When(internalast.Duration(100).ToMilliseconds()),
 		},
 	}
 

--- a/ast/operator.go
+++ b/ast/operator.go
@@ -165,3 +165,33 @@ func (lhs Node) IsLoopback() Node {
 func (lhs Node) IsInRange(rhs Node) Node {
 	return wrapNode(lhs.Node.IsInRange(rhs.Node))
 }
+
+//  ____        _       _   _
+// |  _ \  __ _| |_ ___| |_(_)_ __ ___   ___
+// | | | |/ _` | __/ _ \ __| | '_ ` _ \ / _ \
+// | |_| | (_| | ||  __/ |_| | | | | | |  __/
+// |____/ \__,_|\__\___|\__|_|_| |_| |_|\___|
+
+func (lhs Node) Offset(rhs Node) Node { return wrapNode(lhs.Node.Offset(rhs.Node)) }
+
+func (lhs Node) DurationSince(rhs Node) Node { return wrapNode(lhs.Node.DurationSince(rhs.Node)) }
+
+func (lhs Node) ToDate() Node { return wrapNode(lhs.Node.ToDate()) }
+
+func (lhs Node) ToTime() Node { return wrapNode(lhs.Node.ToTime()) }
+
+//  ____                  _   _
+// |  _ \ _   _ _ __ __ _| |_(_) ___  _ __
+// | | | | | | | '__/ _` | __| |/ _ \| '_ \
+// | |_| | |_| | | | (_| | |_| | (_) | | | |
+// |____/ \__,_|_|  \__,_|\__|_|\___/|_| |_|
+
+func (lhs Node) ToDays() Node { return wrapNode(lhs.Node.ToDays()) }
+
+func (lhs Node) ToHours() Node { return wrapNode(lhs.Node.ToHours()) }
+
+func (lhs Node) ToMinutes() Node { return wrapNode(lhs.Node.ToMinutes()) }
+
+func (lhs Node) ToSeconds() Node { return wrapNode(lhs.Node.ToSeconds()) }
+
+func (lhs Node) ToMilliseconds() Node { return wrapNode(lhs.Node.ToMilliseconds()) }

--- a/ast/value.go
+++ b/ast/value.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"net/netip"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/ast"
 	"github.com/cedar-policy/cedar-go/types"
@@ -77,6 +78,14 @@ func EntityUID(typ types.Ident, id types.String) Node {
 // IPAddr creates an value node containing an IPAddr.
 func IPAddr[T netip.Prefix | types.IPAddr](i T) Node {
 	return wrapNode(ast.IPAddr(types.IPAddr(i)))
+}
+
+func Datetime(t time.Time) Node {
+	return Value(types.FromStdTime(t))
+}
+
+func Duration(d time.Duration) Node {
+	return Value(types.FromStdDuration(d))
 }
 
 // Value creates a value node from any value.

--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -3,6 +3,7 @@ package ast_test
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/ast"
 	"github.com/cedar-policy/cedar-go/internal/testutil"
@@ -479,6 +480,59 @@ func TestASTByTable(t *testing.T) {
 			ast.Permit().When(ast.Long(42).IsInRange(ast.Long(43))),
 			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
 				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "isInRange", Args: []ast.IsNode{ast.NodeValue{Value: types.Long(42)}, ast.NodeValue{Value: types.Long(43)}}}}}},
+		},
+		{
+			"opOffset",
+			ast.Permit().When(ast.Datetime(time.Time{}).Offset(ast.Duration(time.Duration(100)))),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "offset", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdTime(time.Time{})}, ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
+		},
+		{
+			"opDurationSince",
+			ast.Permit().When(ast.Datetime(time.Time{}).DurationSince(ast.Datetime(time.Time{}))),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "durationSince", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdTime(time.Time{})}, ast.NodeValue{Value: types.FromStdTime(time.Time{})}}}}}},
+		},
+		{
+			"opToDate",
+			ast.Permit().When(ast.Datetime(time.Time{}).ToDate()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toDate", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdTime(time.Time{})}}}}}},
+		},
+		{
+			"opToTime",
+			ast.Permit().When(ast.Datetime(time.Time{}).ToTime()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toTime", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdTime(time.Time{})}}}}}},
+		},
+		{
+			"opToDays",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToDays()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toDays", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
+		},
+		{
+			"opToHours",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToHours()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toHours", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
+		},
+		{"opToMinutes",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToMinutes()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toMinutes", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
+		},
+		{
+			"opToSeconds",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToSeconds()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toSeconds", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
+		},
+		{
+			"opToMilliseconds",
+			ast.Permit().When(ast.Duration(time.Duration(100)).ToMilliseconds()),
+			ast.Policy{Effect: ast.EffectPermit, Principal: ast.ScopeTypeAll{}, Action: ast.ScopeTypeAll{}, Resource: ast.ScopeTypeAll{},
+				Conditions: []ast.ConditionType{{Condition: ast.ConditionWhen, Body: ast.NodeTypeExtensionCall{Name: "toMilliseconds", Args: []ast.IsNode{ast.NodeValue{Value: types.FromStdDuration(time.Duration(100))}}}}}},
 		},
 
 		{

--- a/internal/ast/operator.go
+++ b/internal/ast/operator.go
@@ -162,3 +162,33 @@ func (lhs Node) IsLoopback() Node {
 func (lhs Node) IsInRange(rhs Node) Node {
 	return NewMethodCall(lhs, "isInRange", rhs)
 }
+
+//  ____        _       _   _
+// |  _ \  __ _| |_ ___| |_(_)_ __ ___   ___
+// | | | |/ _` | __/ _ \ __| | '_ ` _ \ / _ \
+// | |_| | (_| | ||  __/ |_| | | | | | |  __/
+// |____/ \__,_|\__\___|\__|_|_| |_| |_|\___|
+
+func (lhs Node) Offset(rhs Node) Node { return NewMethodCall(lhs, "offset", rhs) }
+
+func (lhs Node) DurationSince(rhs Node) Node { return NewMethodCall(lhs, "durationSince", rhs) }
+
+func (lhs Node) ToDate() Node { return NewMethodCall(lhs, "toDate") }
+
+func (lhs Node) ToTime() Node { return NewMethodCall(lhs, "toTime") }
+
+//  ____                  _   _
+// |  _ \ _   _ _ __ __ _| |_(_) ___  _ __
+// | | | | | | | '__/ _` | __| |/ _ \| '_ \
+// | |_| | |_| | | | (_| | |_| | (_) | | | |
+// |____/ \__,_|_|  \__,_|\__|_|\___/|_| |_|
+
+func (lhs Node) ToDays() Node { return NewMethodCall(lhs, "toDays") }
+
+func (lhs Node) ToHours() Node { return NewMethodCall(lhs, "toHours") }
+
+func (lhs Node) ToMinutes() Node { return NewMethodCall(lhs, "toMinutes") }
+
+func (lhs Node) ToSeconds() Node { return NewMethodCall(lhs, "toSeconds") }
+
+func (lhs Node) ToMilliseconds() Node { return NewMethodCall(lhs, "toMilliseconds") }

--- a/internal/ast/value.go
+++ b/internal/ast/value.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"net/netip"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/types"
 )
@@ -71,6 +72,14 @@ func EntityUID(typ types.Ident, id types.String) Node {
 
 func IPAddr[T netip.Prefix | types.IPAddr](i T) Node {
 	return Value(types.IPAddr(i))
+}
+
+func Datetime(t time.Time) Node {
+	return Value(types.FromStdTime(t))
+}
+
+func Duration(d time.Duration) Node {
+	return Value(types.FromStdDuration(d))
 }
 
 func ExtensionCall(name types.Path, args ...Node) Node {

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -24,16 +24,16 @@ var ExtMap = map[types.Path]extInfo{
 	"isMulticast": {Args: 1, IsMethod: true},
 	"isInRange":   {Args: 2, IsMethod: true},
 
-	"toDate":         {Args: 1, IsMethod: true},
-	"toTime":         {Args: 1, IsMethod: true},
+	"toDate":        {Args: 1, IsMethod: true},
+	"toTime":        {Args: 1, IsMethod: true},
+	"offset":        {Args: 2, IsMethod: true},
+	"durationSince": {Args: 2, IsMethod: true},
+
 	"toDays":         {Args: 1, IsMethod: true},
 	"toHours":        {Args: 1, IsMethod: true},
 	"toMinutes":      {Args: 1, IsMethod: true},
 	"toSeconds":      {Args: 1, IsMethod: true},
 	"toMilliseconds": {Args: 1, IsMethod: true},
-
-	"offset":        {Args: 2, IsMethod: true},
-	"durationSince": {Args: 2, IsMethod: true},
 }
 
 func init() {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add missing AST builder methods for datetime and duration literals as well as their associated methods.

