### PR TITLE
types: remove the EntityMap.Load() method and use `[]` instead

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -15,7 +15,7 @@ func TestIsAuthorized(t *testing.T) {
 	tests := []struct {
 		Name                        string
 		Policy                      string
-		Entities                    cedar.Entities
+		Entities                    cedar.EntityMap
 		Principal, Action, Resource cedar.EntityUID
 		Context                     cedar.Record
 		Want                        cedar.Decision
@@ -25,7 +25,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "simple-permit",
 			Policy:    `permit(principal,action,resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -36,7 +36,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "simple-forbid",
 			Policy:    `forbid(principal,action,resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -47,7 +47,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "no-permit",
 			Policy:    `permit(principal,action,resource in asdf::"1234");`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -58,7 +58,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "error-in-policy",
 			Policy:    `permit(principal,action,resource) when { resource in "foo" };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -71,7 +71,7 @@ func TestIsAuthorized(t *testing.T) {
 			Policy: `permit(principal,action,resource) when { resource in "foo" };
 			permit(principal,action,resource);
 			`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -82,7 +82,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-requires-context-success",
 			Policy:    `permit(principal,action,resource) when { context.x == 42 };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -93,7 +93,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-requires-context-fail",
 			Policy:    `permit(principal,action,resource) when { context.x == 42 };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -104,7 +104,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-requires-entities-success",
 			Policy: `permit(principal,action,resource) when { principal.x == 42 };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cuzco: cedar.Entity{
 					UID:        cuzco,
 					Attributes: cedar.NewRecord(cedar.RecordMap{"x": cedar.Long(42)}),
@@ -120,7 +120,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-requires-entities-fail",
 			Policy: `permit(principal,action,resource) when { principal.x == 42 };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cuzco: cedar.Entity{
 					UID:        cuzco,
 					Attributes: cedar.NewRecord(cedar.RecordMap{"x": cedar.Long(43)}),
@@ -136,7 +136,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-requires-entities-parent-success",
 			Policy: `permit(principal,action,resource) when { principal in parent::"bob" };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cuzco: cedar.Entity{
 					UID:     cuzco,
 					Parents: cedar.NewEntityUIDSet(cedar.NewEntityUID("parent", "bob")),
@@ -152,7 +152,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-principal-equals",
 			Policy:    `permit(principal == coder::"cuzco",action,resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -163,7 +163,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-principal-in",
 			Policy: `permit(principal in team::"osiris",action,resource);`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cuzco: cedar.Entity{
 					UID:     cuzco,
 					Parents: cedar.NewEntityUIDSet(cedar.NewEntityUID("team", "osiris")),
@@ -179,7 +179,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-action-equals",
 			Policy:    `permit(principal,action == table::"drop",resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -190,7 +190,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-action-in",
 			Policy: `permit(principal,action in scary::"stuff",resource);`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				dropTable: cedar.Entity{
 					UID:     dropTable,
 					Parents: cedar.NewEntityUIDSet(cedar.NewEntityUID("scary", "stuff")),
@@ -206,7 +206,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-action-in-set",
 			Policy: `permit(principal,action in [scary::"stuff"],resource);`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				dropTable: cedar.Entity{
 					UID:     dropTable,
 					Parents: cedar.NewEntityUIDSet(cedar.NewEntityUID("scary", "stuff")),
@@ -222,7 +222,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-resource-equals",
 			Policy:    `permit(principal,action,resource == table::"whatever");`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -233,7 +233,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-unless",
 			Policy:    `permit(principal,action,resource) unless { false };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -244,7 +244,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-if",
 			Policy:    `permit(principal,action,resource) when { (if true then true else true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -255,7 +255,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-or",
 			Policy:    `permit(principal,action,resource) when { (true || false) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -266,7 +266,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-and",
 			Policy:    `permit(principal,action,resource) when { (true && true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -277,7 +277,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-relations",
 			Policy:    `permit(principal,action,resource) when { (1<2) && (1<=1) && (2>1) && (1>=1) && (1!=2) && (1==1)};`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -288,7 +288,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-relations-in",
 			Policy:    `permit(principal,action,resource) when { principal in principal };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -299,7 +299,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "permit-when-relations-has",
 			Policy: `permit(principal,action,resource) when { principal has name };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cuzco: cedar.Entity{
 					UID:        cuzco,
 					Attributes: cedar.NewRecord(cedar.RecordMap{"name": cedar.String("bob")}),
@@ -315,7 +315,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-add-sub",
 			Policy:    `permit(principal,action,resource) when { 40+3-1==42 };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -326,7 +326,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-mul",
 			Policy:    `permit(principal,action,resource) when { 6*7==42 };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -337,7 +337,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-negate",
 			Policy:    `permit(principal,action,resource) when { -42==-42 };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -348,7 +348,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-not",
 			Policy:    `permit(principal,action,resource) when { !(1+1==42) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -359,7 +359,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].contains(2) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -370,7 +370,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-record",
 			Policy:    `permit(principal,action,resource) when { {name:"bob"} has name };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -381,7 +381,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-action",
 			Policy:    `permit(principal,action,resource) when { action in action };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -392,7 +392,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-contains-ok",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].contains(2) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -403,7 +403,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-contains-error",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].contains(2,3) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -415,7 +415,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-containsAll-ok",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].containsAll([2,3]) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -426,7 +426,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-containsAll-error",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].containsAll(2,3) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -438,7 +438,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-containsAny-ok",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].containsAny([2,5]) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -449,7 +449,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-set-containsAny-error",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].containsAny(2,5) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -461,7 +461,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-record-attr",
 			Policy:    `permit(principal,action,resource) when { {name:"bob"}["name"] == "bob" };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -472,7 +472,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-unknown-method",
 			Policy:    `permit(principal,action,resource) when { [1,2,3].shuffle() };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -484,7 +484,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-like",
 			Policy:    `permit(principal,action,resource) when { "bananas" like "*nan*" };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -495,7 +495,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-unknown-ext-fun",
 			Policy:    `permit(principal,action,resource) when { fooBar("10") };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -511,7 +511,7 @@ func TestIsAuthorized(t *testing.T) {
 				decimal("10.0").lessThanOrEqual(decimal("11.0")) &&
 				decimal("10.0").greaterThan(decimal("9.0")) &&
 				decimal("10.0").greaterThanOrEqual(decimal("9.0")) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -522,7 +522,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-decimal-fun-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { decimal(1, 2) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -538,7 +538,7 @@ func TestIsAuthorized(t *testing.T) {
 				datetime("1970-01-01T09:08:07Z") > (datetime("1970-01-01")) &&
 				datetime("1970-01-01T09:08:07Z") >= (datetime("1970-01-01")) &&
         datetime("1970-01-01T09:08:07Z").toDate() == datetime("1970-01-01")};`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -549,7 +549,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-datetime-fun-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { datetime("1970-01-01", "UTC") };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -573,7 +573,7 @@ func TestIsAuthorized(t *testing.T) {
         datetime("1970-01-01").offset(duration("1ms")).toTime() == duration("1ms") &&
         datetime("1970-01-01T00:00:00.001Z").durationSince(datetime("1970-01-01")) == duration("1ms")};`,
 
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -584,7 +584,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-duration-fun-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { duration("1h", "huh?") };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -600,7 +600,7 @@ func TestIsAuthorized(t *testing.T) {
 				ip("::1").isLoopback() &&
 				ip("224.1.2.3").isMulticast() &&
 				ip("127.0.0.1").isInRange(ip("127.0.0.0/16"))};`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -611,7 +611,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-ip-fun-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip() };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -622,7 +622,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-isIpv4-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip("1.2.3.4").isIpv4(true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -633,7 +633,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-isIpv6-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip("1.2.3.4").isIpv6(true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -644,7 +644,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-isLoopback-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip("1.2.3.4").isLoopback(true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -655,7 +655,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-isMulticast-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip("1.2.3.4").isMulticast(true) };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -666,7 +666,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "permit-when-isInRange-wrong-arity",
 			Policy:    `permit(principal,action,resource) when { ip("1.2.3.4").isInRange() };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cuzco,
 			Action:    dropTable,
 			Resource:  cedar.NewEntityUID("table", "whatever"),
@@ -677,7 +677,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:     "negative-unary-op",
 			Policy:   `permit(principal,action,resource) when { -context.value > 0 };`,
-			Entities: cedar.Entities{},
+			Entities: cedar.EntityMap{},
 			Context:  cedar.NewRecord(cedar.RecordMap{"value": cedar.Long(-42)}),
 			Want:     true,
 			DiagErr:  0,
@@ -685,7 +685,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "principal-is",
 			Policy:    `permit(principal is Actor,action,resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -696,7 +696,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "principal-is-in",
 			Policy:    `permit(principal is Actor in Actor::"cuzco",action,resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -707,7 +707,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "resource-is",
 			Policy:    `permit(principal,action,resource is Resource);`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -718,7 +718,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "resource-is-in",
 			Policy:    `permit(principal,action,resource is Resource in Resource::"table");`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -729,7 +729,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "when-is",
 			Policy:    `permit(principal,action,resource) when { resource is Resource };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -740,7 +740,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:      "when-is-in",
 			Policy:    `permit(principal,action,resource) when { resource is Resource in Resource::"table" };`,
-			Entities:  cedar.Entities{},
+			Entities:  cedar.EntityMap{},
 			Principal: cedar.NewEntityUID("Actor", "cuzco"),
 			Action:    cedar.NewEntityUID("Action", "drop"),
 			Resource:  cedar.NewEntityUID("Resource", "table"),
@@ -751,7 +751,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "when-is-in",
 			Policy: `permit(principal,action,resource) when { resource is Resource in Parent::"id" };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cedar.NewEntityUID("Resource", "table"): cedar.Entity{
 					UID:     cedar.NewEntityUID("Resource", "table"),
 					Parents: cedar.NewEntityUIDSet(cedar.NewEntityUID("Parent", "id")),
@@ -767,7 +767,7 @@ func TestIsAuthorized(t *testing.T) {
 		{
 			Name:   "rfc-57", // https://github.com/cedar-policy/rfcs/blob/main/text/0057-general-multiplication.md
 			Policy: `permit(principal, action, resource) when { context.foo * principal.bar >= 100 };`,
-			Entities: cedar.Entities{
+			Entities: cedar.EntityMap{
 				cedar.NewEntityUID("Principal", "1"): cedar.Entity{
 					UID:        cedar.NewEntityUID("Principal", "1"),
 					Attributes: cedar.NewRecord(cedar.RecordMap{"bar": cedar.Long(42)}),

--- a/corpus_test.go
+++ b/corpus_test.go
@@ -141,7 +141,7 @@ func TestCorpus(t *testing.T) {
 				t.Fatal("error reading entities content", err)
 			}
 
-			var entities cedar.Entities
+			var entities cedar.EntityMap
 			if err := json.Unmarshal(entitiesContent, &entities); err != nil {
 				t.Fatal("error unmarshalling test", err)
 			}
@@ -384,7 +384,7 @@ func TestCorpusRelated(t *testing.T) {
 			t.Parallel()
 			policy, err := cedar.NewPolicySetFromBytes("", []byte(tt.policy))
 			testutil.OK(t, err)
-			ok, diag := policy.IsAuthorized(cedar.Entities{}, tt.request)
+			ok, diag := policy.IsAuthorized(cedar.EntityMap{}, tt.request)
 			testutil.Equals(t, ok, tt.decision)
 			var reasons []cedar.PolicyID
 			for _, n := range diag.Reasons {

--- a/internal/eval/evalers.go
+++ b/internal/eval/evalers.go
@@ -854,7 +854,7 @@ func (n *attributeAccessEval) Eval(env Env) (types.Value, error) {
 		if vv == unspecified {
 			return zeroValue(), fmt.Errorf("cannot access attribute `%s` of %w", n.attribute, errUnspecifiedEntity)
 		}
-		rec, ok := env.Entities.Load(vv)
+		rec, ok := env.Entities[vv]
 		if !ok {
 			return zeroValue(), fmt.Errorf("entity `%v` %w", vv.String(), errEntityNotExist)
 		}
@@ -892,7 +892,7 @@ func (n *hasEval) Eval(env Env) (types.Value, error) {
 	var record types.Record
 	switch vv := v.(type) {
 	case types.EntityUID:
-		if rec, ok := env.Entities.Load(vv); ok {
+		if rec, ok := env.Entities[vv]; ok {
 			record = rec.Attributes
 		}
 	case types.Record:
@@ -961,12 +961,12 @@ func entityInOne(env Env, entity types.EntityUID, parent types.EntityUID) bool {
 	var todo []types.EntityUID
 	var candidate = entity
 	for {
-		if fe, ok := env.Entities.Load(candidate); ok {
+		if fe, ok := env.Entities[candidate]; ok {
 			if fe.Parents.Contains(parent) {
 				return true
 			}
 			fe.Parents.Iterate(func(k types.EntityUID) bool {
-				p, ok := env.Entities.Load(k)
+				p, ok := env.Entities[k]
 				if !ok || p.Parents.Len() == 0 || k == entity || known.Contains(k) {
 					return true
 				}
@@ -990,12 +990,12 @@ func entityInSet(env Env, entity types.EntityUID, parents mapset.Container[types
 	var todo []types.EntityUID
 	var candidate = entity
 	for {
-		if fe, ok := env.Entities.Load(candidate); ok {
+		if fe, ok := env.Entities[candidate]; ok {
 			if fe.Parents.Intersects(parents) {
 				return true
 			}
 			fe.Parents.Iterate(func(k types.EntityUID) bool {
-				p, ok := env.Entities.Load(k)
+				p, ok := env.Entities[k]
 				if !ok || p.Parents.Len() == 0 || k == entity || known.Contains(k) {
 					return true
 				}

--- a/internal/eval/partial.go
+++ b/internal/eval/partial.go
@@ -504,7 +504,7 @@ func (n *partialHasEval) Eval(env Env) (types.Value, error) {
 	var record types.Record
 	switch vv := v.(type) {
 	case types.EntityUID:
-		if rec, ok := env.Entities.Load(vv); ok {
+		if rec, ok := env.Entities[vv]; ok {
 			record = rec.Attributes
 		}
 	case types.Record:

--- a/types.go
+++ b/types.go
@@ -31,7 +31,7 @@ type String = types.String
 
 // Other Cedar types
 
-type Entities = types.EntityMap
+type EntityMap = types.EntityMap
 type Entity = types.Entity
 type EntityType = types.EntityType
 type EntityUIDSet = types.EntityUIDSet

--- a/types/entity_map.go
+++ b/types/entity_map.go
@@ -13,11 +13,6 @@ import (
 // the Entity (it must be the same as the UID within the Entity itself.)
 type EntityMap map[EntityUID]Entity
 
-func (e EntityMap) Load(k EntityUID) (Entity, bool) {
-	v, ok := e[k]
-	return v, ok
-}
-
 func (e EntityMap) MarshalJSON() ([]byte, error) {
 	s := maps.Values(e)
 	slices.SortFunc(s, func(a, b Entity) int {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* See title

Also, rename `cedar.Entities` to `cedar.EntityMap` to match the new name in the `types` package.


