### PR TITLE
types: clean up JSON unmarshaling story for extension types

### DIFF
--- a/types/datetime.go
+++ b/types/datetime.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -251,34 +250,11 @@ func (a Datetime) String() string {
 // - { "fn": "datetime", "arg": "1970-01-01" }
 // - "1970-01-01"
 func (a *Datetime) UnmarshalJSON(b []byte) error {
-	var arg string
-	if len(b) > 0 && b[0] == '"' {
-		if err := json.Unmarshal(b, &arg); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-	} else {
-		var res extValueJSON
-		if err := json.Unmarshal(b, &res); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-		if res.Extn == nil {
-			// If we didn't find an Extn, maybe it's just an extn.
-			var res2 extn
-			json.Unmarshal(b, &res2)
-			// We've tried Ext.Fn and Fn, so no good.
-			if res2.Fn == "" {
-				return errJSONExtNotFound
-			}
-			if res2.Fn != "datetime" {
-				return errJSONExtFnMatch
-			}
-			arg = res2.Arg
-		} else if res.Extn.Fn != "datetime" {
-			return errJSONExtFnMatch
-		} else {
-			arg = res.Extn.Arg
-		}
+	arg, err := unmarshalExtensionArg(b, "datetime")
+	if err != nil {
+		return err
 	}
+
 	aa, err := ParseDatetime(arg)
 	if err != nil {
 		return err

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -247,16 +246,13 @@ func (a Datetime) String() string {
 
 // UnmarshalJSON implements encoding/json.Unmarshaler for Datetime
 //
-// It is capable of unmarshaling 4 different representations supported by Cedar
+// It is capable of unmarshaling 3 different representations supported by Cedar
 // - { "__extn": { "fn": "datetime", "arg": "1970-01-01" }}
 // - { "fn": "datetime", "arg": "1970-01-01" }
-// - "datetime(\"1970-01-01\")"
 // - "1970-01-01"
 func (a *Datetime) UnmarshalJSON(b []byte) error {
 	var arg string
-	if bytes.HasPrefix(b, []byte(`"datetime(\"`)) && bytes.HasSuffix(b, []byte(`\")"`)) {
-		arg = string(b[12 : len(b)-4])
-	} else if len(b) > 0 && b[0] == '"' {
+	if len(b) > 0 && b[0] == '"' {
 		if err := json.Unmarshal(b, &arg); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -246,9 +246,9 @@ func (a Datetime) String() string {
 // UnmarshalJSON implements encoding/json.Unmarshaler for Datetime
 //
 // It is capable of unmarshaling 3 different representations supported by Cedar
-// - { "__extn": { "fn": "datetime", "arg": "1970-01-01" }}
-// - { "fn": "datetime", "arg": "1970-01-01" }
-// - "1970-01-01"
+//   - { "__extn": { "fn": "datetime", "arg": "1970-01-01" }}
+//   - { "fn": "datetime", "arg": "1970-01-01" }
+//   - "1970-01-01"
 func (a *Datetime) UnmarshalJSON(b []byte) error {
 	aa, err := unmarshalExtensionValue(b, "datetime", ParseDatetime)
 	if err != nil {

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -250,15 +250,11 @@ func (a Datetime) String() string {
 // - { "fn": "datetime", "arg": "1970-01-01" }
 // - "1970-01-01"
 func (a *Datetime) UnmarshalJSON(b []byte) error {
-	arg, err := unmarshalExtensionArg(b, "datetime")
+	aa, err := unmarshalExtensionValue(b, "datetime", ParseDatetime)
 	if err != nil {
 		return err
 	}
 
-	aa, err := ParseDatetime(arg)
-	if err != nil {
-		return err
-	}
 	*a = aa
 	return nil
 }

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -197,8 +198,25 @@ func TestDatetime(t *testing.T) {
 
 	t.Run("MarshalJSON", func(t *testing.T) {
 		t.Parallel()
-		bs, err := types.NewDatetime(time.UnixMilli(42)).MarshalJSON()
+		expected := `{
+			"__extn": {
+				"fn": "datetime",
+				"arg": "1970-01-01T00:00:00.042Z"
+			}
+		}`
+		dt1 := types.NewDatetime(time.UnixMilli(42))
+		testutil.JSONMarshalsTo(t, dt1, expected)
+
+		var dt2 types.Datetime
+		err := json.Unmarshal([]byte(expected), &dt2)
 		testutil.OK(t, err)
-		testutil.Equals(t, string(bs), `{"__extn":{"fn":"datetime","arg":"1970-01-01T00:00:00.042Z"}}`)
+		testutil.Equals(t, dt1, dt2)
+	})
+
+	t.Run("UnmarshalJSON/error", func(t *testing.T) {
+		t.Parallel()
+		var dt2 types.Datetime
+		err := json.Unmarshal([]byte("{}"), &dt2)
+		testutil.Error(t, err)
 	})
 }

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -169,7 +169,6 @@ func (d *Decimal) UnmarshalJSON(b []byte) error {
 	} else {
 		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
 		// The following are not supported:
-		// "decimal(\"1234.5678\")"
 		// {"fn":"decimal","arg":"1234.5678"}
 		var res extValueJSON
 		if err := json.Unmarshal(b, &res); err != nil {

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -160,17 +160,19 @@ func (d Decimal) String() string {
 	return res[:right]
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler for Decimal
+//
+// It is capable of unmarshaling 3 different representations supported by Cedar
+// - { "__extn": { "fn": "decimal", "arg": "1234.5678" }}
+// - { "fn": "decimal", "arg": "1234.5678" }
+// - "1234.5678"
 func (d *Decimal) UnmarshalJSON(b []byte) error {
-	arg, err := unmarshalExtensionArg(b, "decimal")
+	dd, err := unmarshalExtensionValue(b, "decimal", ParseDecimal)
 	if err != nil {
 		return err
 	}
 
-	vv, err := ParseDecimal(arg)
-	if err != nil {
-		return err
-	}
-	*d = vv
+	*d = dd
 	return nil
 }
 

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -163,9 +163,9 @@ func (d Decimal) String() string {
 // UnmarshalJSON implements encoding/json.Unmarshaler for Decimal
 //
 // It is capable of unmarshaling 3 different representations supported by Cedar
-// - { "__extn": { "fn": "decimal", "arg": "1234.5678" }}
-// - { "fn": "decimal", "arg": "1234.5678" }
-// - "1234.5678"
+//   - { "__extn": { "fn": "decimal", "arg": "1234.5678" }}
+//   - { "fn": "decimal", "arg": "1234.5678" }
+//   - "1234.5678"
 func (d *Decimal) UnmarshalJSON(b []byte) error {
 	dd, err := unmarshalExtensionValue(b, "decimal", ParseDecimal)
 	if err != nil {

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -161,27 +161,11 @@ func (d Decimal) String() string {
 }
 
 func (d *Decimal) UnmarshalJSON(b []byte) error {
-	var arg string
-	if len(b) > 0 && b[0] == '"' {
-		if err := json.Unmarshal(b, &arg); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-	} else {
-		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
-		// The following are not supported:
-		// {"fn":"decimal","arg":"1234.5678"}
-		var res extValueJSON
-		if err := json.Unmarshal(b, &res); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-		if res.Extn == nil {
-			return errJSONExtNotFound
-		}
-		if res.Extn.Fn != "decimal" {
-			return errJSONExtFnMatch
-		}
-		arg = res.Extn.Arg
+	arg, err := unmarshalExtensionArg(b, "decimal")
+	if err != nil {
+		return err
 	}
+
 	vv, err := ParseDecimal(arg)
 	if err != nil {
 		return err

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -286,5 +287,29 @@ func TestDecimal(t *testing.T) {
 			t,
 			string(testutil.Must(types.NewDecimal(42, 0)).MarshalCedar()),
 			`decimal("42.0")`)
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		expected := `{
+			"__extn": {
+				"fn": "decimal",
+				"arg": "1234.5678"
+			}
+		}`
+		d1 := testutil.Must(types.NewDecimal(12345678, -4))
+		testutil.JSONMarshalsTo(t, d1, expected)
+
+		var d2 types.Decimal
+		err := json.Unmarshal([]byte(expected), &d2)
+		testutil.OK(t, err)
+		testutil.Equals(t, d1, d2)
+	})
+
+	t.Run("UnmarshalJSON/error", func(t *testing.T) {
+		t.Parallel()
+		var dt2 types.Decimal
+		err := json.Unmarshal([]byte("{}"), &dt2)
+		testutil.Error(t, err)
 	})
 }

--- a/types/duration.go
+++ b/types/duration.go
@@ -214,9 +214,9 @@ func (v Duration) String() string {
 // UnmarshalJSON implements encoding/json.Unmarshaler for Duration
 //
 // It is capable of unmarshaling 3 different representations supported by Cedar
-// - { "__extn": { "fn": "duration", "arg": "1h10m" }}
-// - { "fn": "duration", "arg": "1h10m" }
-// - "1h10m"
+//   - { "__extn": { "fn": "duration", "arg": "1h10m" }}
+//   - { "fn": "duration", "arg": "1h10m" }
+//   - "1h10m"
 func (v *Duration) UnmarshalJSON(b []byte) error {
 	vv, err := unmarshalExtensionValue(b, "duration", ParseDuration)
 	if err != nil {

--- a/types/duration.go
+++ b/types/duration.go
@@ -218,15 +218,11 @@ func (v Duration) String() string {
 // - { "fn": "duration", "arg": "1h10m" }
 // - "1h10m"
 func (v *Duration) UnmarshalJSON(b []byte) error {
-	arg, err := unmarshalExtensionArg(b, "duration")
+	vv, err := unmarshalExtensionValue(b, "duration", ParseDuration)
 	if err != nil {
 		return err
 	}
 
-	vv, err := ParseDuration(arg)
-	if err != nil {
-		return err
-	}
 	*v = vv
 	return nil
 }

--- a/types/duration.go
+++ b/types/duration.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -219,34 +218,11 @@ func (v Duration) String() string {
 // - { "fn": "duration", "arg": "1h10m" }
 // - "1h10m"
 func (v *Duration) UnmarshalJSON(b []byte) error {
-	var arg string
-	if len(b) > 0 && b[0] == '"' {
-		if err := json.Unmarshal(b, &arg); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-	} else {
-		var res extValueJSON
-		if err := json.Unmarshal(b, &res); err != nil {
-			return errors.Join(errJSONDecode, err)
-		}
-		if res.Extn == nil {
-			// If we didn't find an Extn, maybe it's just an extn.
-			var res2 extn
-			json.Unmarshal(b, &res2)
-			// We've tried Ext.Fn and Fn, so no good.
-			if res2.Fn == "" {
-				return errJSONExtNotFound
-			}
-			if res2.Fn != "duration" {
-				return errJSONExtFnMatch
-			}
-			arg = res2.Arg
-		} else if res.Extn.Fn != "duration" {
-			return errJSONExtFnMatch
-		} else {
-			arg = res.Extn.Arg
-		}
+	arg, err := unmarshalExtensionArg(b, "duration")
+	if err != nil {
+		return err
 	}
+
 	vv, err := ParseDuration(arg)
 	if err != nil {
 		return err

--- a/types/duration.go
+++ b/types/duration.go
@@ -214,16 +214,13 @@ func (v Duration) String() string {
 
 // UnmarshalJSON implements encoding/json.Unmarshaler for Duration
 //
-// It is capable of unmarshaling 4 different representations supported by Cedar
+// It is capable of unmarshaling 3 different representations supported by Cedar
 // - { "__extn": { "fn": "duration", "arg": "1h10m" }}
 // - { "fn": "duration", "arg": "1h10m" }
-// - "duration(\"1h10m\")"
 // - "1h10m"
 func (v *Duration) UnmarshalJSON(b []byte) error {
 	var arg string
-	if bytes.HasPrefix(b, []byte(`"duration(\"`)) && bytes.HasSuffix(b, []byte(`\")"`)) {
-		arg = string(b[12 : len(b)-4])
-	} else if len(b) > 0 && b[0] == '"' {
+	if len(b) > 0 && b[0] == '"' {
 		if err := json.Unmarshal(b, &arg); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -176,8 +177,25 @@ func TestDuration(t *testing.T) {
 
 	t.Run("MarshalJSON", func(t *testing.T) {
 		t.Parallel()
-		bs, err := types.NewDuration(42 * time.Millisecond).MarshalJSON()
+		expected := `{
+			"__extn": {
+				"fn": "duration",
+				"arg": "42ms"
+			}
+		}`
+		d1 := types.NewDuration(42 * time.Millisecond)
+		testutil.JSONMarshalsTo(t, d1, expected)
+
+		var d2 types.Duration
+		err := json.Unmarshal([]byte(expected), &d2)
 		testutil.OK(t, err)
-		testutil.Equals(t, string(bs), `{"__extn":{"fn":"duration","arg":"42ms"}}`)
+		testutil.Equals(t, d1, d2)
+	})
+
+	t.Run("UnmarshalJSON/error", func(t *testing.T) {
+		t.Parallel()
+		var dt2 types.Duration
+		err := json.Unmarshal([]byte("{}"), &dt2)
+		testutil.Error(t, err)
 	})
 }

--- a/types/ipaddr.go
+++ b/types/ipaddr.go
@@ -106,9 +106,9 @@ func (c IPAddr) Contains(o IPAddr) bool {
 // UnmarshalJSON implements encoding/json.Unmarshaler for IPAddr
 //
 // It is capable of unmarshaling 3 different representations supported by Cedar
-// - { "__extn": { "fn": "ip", "arg": "12.34.56.78" }}
-// - { "fn": "ip", "arg": "12.34.56.78" }
-// - "12.34.56.78"
+//   - { "__extn": { "fn": "ip", "arg": "12.34.56.78" }}
+//   - { "fn": "ip", "arg": "12.34.56.78" }
+//   - "12.34.56.78"
 func (v *IPAddr) UnmarshalJSON(b []byte) error {
 	vv, err := unmarshalExtensionValue(b, "ip", ParseIPAddr)
 	if err != nil {

--- a/types/ipaddr.go
+++ b/types/ipaddr.go
@@ -103,16 +103,18 @@ func (c IPAddr) Contains(o IPAddr) bool {
 	return c.Prefix().Contains(o.Addr()) && c.Prefix().Bits() <= o.Prefix().Bits()
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler for IPAddr
+//
+// It is capable of unmarshaling 3 different representations supported by Cedar
+// - { "__extn": { "fn": "ip", "arg": "12.34.56.78" }}
+// - { "fn": "ip", "arg": "12.34.56.78" }
+// - "12.34.56.78"
 func (v *IPAddr) UnmarshalJSON(b []byte) error {
-	arg, err := unmarshalExtensionArg(b, "ip")
+	vv, err := unmarshalExtensionValue(b, "ip", ParseIPAddr)
 	if err != nil {
 		return err
 	}
 
-	vv, err := ParseIPAddr(arg)
-	if err != nil {
-		return err
-	}
 	*v = vv
 	return nil
 }

--- a/types/ipaddr_test.go
+++ b/types/ipaddr_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -277,4 +278,27 @@ func TestIP(t *testing.T) {
 			`ip("10.0.0.42")`)
 	})
 
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		expected := `{
+			"__extn": {
+				"fn": "ip",
+				"arg": "12.34.56.78"
+			}
+		}`
+		i1 := testutil.Must(types.ParseIPAddr("12.34.56.78"))
+		testutil.JSONMarshalsTo(t, i1, expected)
+
+		var i2 types.IPAddr
+		err := json.Unmarshal([]byte(expected), &i2)
+		testutil.OK(t, err)
+		testutil.Equals(t, i1, i2)
+	})
+
+	t.Run("UnmarshalJSON/error", func(t *testing.T) {
+		t.Parallel()
+		var dt2 types.IPAddr
+		err := json.Unmarshal([]byte("{}"), &dt2)
+		testutil.Error(t, err)
+	})
 }

--- a/types/json.go
+++ b/types/json.go
@@ -142,7 +142,12 @@ func unmarshalExtensionValue[T any](b []byte, extName string, parse func(string)
 		if res.Extn == nil {
 			// If we didn't find an Extn, maybe it's just an extn.
 			var res2 extn
+
+			// N.B. we already know that this JSON unmarshals successfully as a struct, so it's
+			// not actually possible to get an error here. Hence, it's safe to ignore the return
+			// value.
 			_ = json.Unmarshal(b, &res2)
+
 			// We've tried Ext.Fn and Fn, so no good.
 			if res2.Fn == "" {
 				return zeroT, errJSONExtNotFound

--- a/types/json.go
+++ b/types/json.go
@@ -143,10 +143,9 @@ func unmarshalExtensionValue[T any](b []byte, extName string, parse func(string)
 			// If we didn't find an Extn, maybe it's just an extn.
 			var res2 extn
 
-			// N.B. we already know that this JSON unmarshals successfully as a struct, so it's
-			// not actually possible to get an error here. Hence, it's safe to ignore the return
-			// value.
-			_ = json.Unmarshal(b, &res2)
+			if err := json.Unmarshal(b, &res2); err != nil {
+				return zeroT, errors.Join(errJSONDecode, err)
+			}
 
 			// We've tried Ext.Fn and Fn, so no good.
 			if res2.Fn == "" {

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -273,7 +273,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 		},
 
 		{
-			name: "datetime",
+			name: "datetime/explicit",
 			f: func(b []byte) (Value, error) {
 				var res Datetime
 				err := (&res).UnmarshalJSON(b)
@@ -284,7 +284,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "datetime/implicit",
+			name: "datetime/implicit/string",
 			f: func(b []byte) (Value, error) {
 				var res Datetime
 				err := (&res).UnmarshalJSON(b)
@@ -295,18 +295,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "datetime/direct",
-			f: func(b []byte) (Value, error) {
-				var res Datetime
-				err := (&res).UnmarshalJSON(b)
-				return res, err
-			},
-			in:        `"datetime(\"1970-01-01T00:00:01Z\")"`,
-			wantValue: mustDatetimeValue("1970-01-01T00:00:01Z"),
-			wantErr:   nil,
-		},
-		{
-			name: "datetime/direct/JSON",
+			name: "datetime/implicit/JSON",
 			f: func(b []byte) (Value, error) {
 				var res Datetime
 				err := (&res).UnmarshalJSON(b)
@@ -396,7 +385,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 		},
 
 		{
-			name: "duration",
+			name: "duration/explicit",
 			f: func(b []byte) (Value, error) {
 				var res Duration
 				err := (&res).UnmarshalJSON(b)
@@ -407,7 +396,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "duration/implicit",
+			name: "duration/implicit/string",
 			f: func(b []byte) (Value, error) {
 				var res Duration
 				err := (&res).UnmarshalJSON(b)
@@ -418,18 +407,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "duration/direct",
-			f: func(b []byte) (Value, error) {
-				var res Duration
-				err := (&res).UnmarshalJSON(b)
-				return res, err
-			},
-			in:        `"duration(\"1ms\")"`,
-			wantValue: mustDurationValue("1ms"),
-			wantErr:   nil,
-		},
-		{
-			name: "duration/direct/JSON",
+			name: "duration/implicit/JSON",
 			f: func(b []byte) (Value, error) {
 				var res Duration
 				err := (&res).UnmarshalJSON(b)

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -117,7 +117,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "ip",
+			name: "ip/explicit",
 			f: func(b []byte) (Value, error) {
 				var res IPAddr
 				err := (&res).UnmarshalJSON(b)
@@ -128,13 +128,24 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "ip/implicit",
+			name: "ip/implicit/string",
 			f: func(b []byte) (Value, error) {
 				var res IPAddr
 				err := (&res).UnmarshalJSON(b)
 				return res, err
 			},
 			in:        `"222.222.222.7"`,
+			wantValue: mustIPValue("222.222.222.7"),
+			wantErr:   nil,
+		},
+		{
+			name: "ip/implicit/JSON",
+			f: func(b []byte) (Value, error) {
+				var res IPAddr
+				err := (&res).UnmarshalJSON(b)
+				return res, err
+			},
+			in:        `{ "fn": "ip", "arg": "222.222.222.7" }`,
 			wantValue: mustIPValue("222.222.222.7"),
 			wantErr:   nil,
 		},
@@ -148,6 +159,17 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			in:        `"bad`,
 			wantValue: IPAddr{},
 			wantErr:   errJSONDecode,
+		},
+		{
+			name: "ip/implicit/notIP",
+			f: func(b []byte) (Value, error) {
+				var res IPAddr
+				err := (&res).UnmarshalJSON(b)
+				return res, err
+			},
+			in:        `{"fn": "datetime"}`,
+			wantValue: IPAddr{},
+			wantErr:   errJSONExtFnMatch,
 		},
 		{
 			name: "ip/badArg",

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -195,7 +195,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 		},
 
 		{
-			name: "decimal",
+			name: "decimal/explicit",
 			f: func(b []byte) (Value, error) {
 				var res Decimal
 				err := (&res).UnmarshalJSON(b)
@@ -206,7 +206,7 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name: "decimal/implicit",
+			name: "decimal/implicit/string",
 			f: func(b []byte) (Value, error) {
 				var res Decimal
 				err := (&res).UnmarshalJSON(b)
@@ -217,15 +217,37 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
+			name: "decimal/implicit/JSON",
+			f: func(b []byte) (Value, error) {
+				var res Decimal
+				err := (&res).UnmarshalJSON(b)
+				return res, err
+			},
+			in:        `{ "fn": "decimal", "arg": "1234.5678" }`,
+			wantValue: mustDecimalValue("1234.5678"),
+			wantErr:   nil,
+		},
+		{
 			name: "decimal/implicit/badJSON",
 			f: func(b []byte) (Value, error) {
 				var res Decimal
 				err := (&res).UnmarshalJSON(b)
 				return res, err
 			},
-			in:        `"bad`,
+			in:        `{"bad": "value"}`,
 			wantValue: Decimal{},
-			wantErr:   errJSONDecode,
+			wantErr:   errJSONExtNotFound,
+		},
+		{
+			name: "decimal/implicit/notDecimal",
+			f: func(b []byte) (Value, error) {
+				var res Decimal
+				err := (&res).UnmarshalJSON(b)
+				return res, err
+			},
+			in:        `{"fn": "datetime"}`,
+			wantValue: Decimal{},
+			wantErr:   errJSONExtFnMatch,
 		},
 		{
 			name: "decimal/badArg",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Create a generic `unmarshalExtensionValue()` helper function that supports all three forms of extension value JSON encoding:

* Explicit: `{ "__extn": { "fn": "decimal", "arg": "1234.5678" } }`
* Implicit object: `{ "fn": "decimal", "arg": "1234.5678" } }`
* Implicit string: `"1234.5678"`

Use it to flesh out the implementations of `UnmarshalJSON` for `IPAddr` and `Decimal`. Note that the implicit decoding will never actually be invoked until we have schema-driven decoding for entities.
