### PR TITLE
IDX-470: Change PolicySet.IsAuthorized to take an EntityGetter interface in place of an EntityMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ Generated documentation for the latest version of the Go implementation can be a
 If you're looking to integrate Cedar into a production system, please be sure the read the [security best practices](https://docs.cedarpolicy.com/other/security.html)
 
 ## Backward Compatibility Considerations
-
-x/exp - code in this directory is not subject to the semantic version constraints of the rest of the module and breaking changes may be made at any time
+- `x/exp` - code in this directory is not subject to the semantic versioning constraints of the rest of the module and breaking changes may be made at any time.
+- Variadics may be added to functions that do not have them to expand the arguments of a function or method.
+- Concrete types may be replaced with compatible interfaces to expand the variety of arguments a function or method can take.
 
 ## Change log
 

--- a/authorize.go
+++ b/authorize.go
@@ -18,7 +18,7 @@ const (
 
 // IsAuthorized uses the combination of the PolicySet and Entities to determine
 // if the given Request to determine Decision and Diagnostic.
-func (p PolicySet) IsAuthorized(entities types.EntityMap, req Request) (Decision, Diagnostic) {
+func (p PolicySet) IsAuthorized(entities types.EntityGetter, req Request) (Decision, Diagnostic) {
 	env := eval.Env{
 		Entities:  entities,
 		Principal: req.Principal,

--- a/internal/eval/partial.go
+++ b/internal/eval/partial.go
@@ -504,7 +504,7 @@ func (n *partialHasEval) Eval(env Env) (types.Value, error) {
 	var record types.Record
 	switch vv := v.(type) {
 	case types.EntityUID:
-		if rec, ok := env.Entities[vv]; ok {
+		if rec, ok := env.Entities.Get(vv); ok {
 			record = rec.Attributes
 		}
 	case types.Record:

--- a/types/entity_map.go
+++ b/types/entity_map.go
@@ -8,6 +8,13 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// An EntityGetter is an interface for retrieving an Entity by EntityUID.
+type EntityGetter interface {
+	Get(uid EntityUID) (Entity, bool)
+}
+
+var _ EntityGetter = EntityMap{}
+
 // An EntityMap is a collection of all the entities that are needed to evaluate
 // authorization requests.  The key is an EntityUID which uniquely identifies
 // the Entity (it must be the same as the UID within the Entity itself.)

--- a/types/entity_map.go
+++ b/types/entity_map.go
@@ -37,3 +37,8 @@ func (e *EntityMap) UnmarshalJSON(b []byte) error {
 func (e EntityMap) Clone() EntityMap {
 	return maps.Clone(e)
 }
+
+func (e EntityMap) Get(uid EntityUID) (Entity, bool) {
+	ent, ok := e[uid]
+	return ent, ok
+}

--- a/types/entity_map_test.go
+++ b/types/entity_map_test.go
@@ -22,6 +22,21 @@ func TestEntities(t *testing.T) {
 		testutil.Equals(t, clone, e)
 	})
 
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		ent := types.Entity{
+			UID:        types.NewEntityUID("Type", "id"),
+			Attributes: types.NewRecord(types.RecordMap{"key": types.Long(42)}),
+		}
+		e := types.EntityMap{
+			ent.UID: ent,
+		}
+		got, ok := e.Get(ent.UID)
+		testutil.Equals(t, ok, true)
+		testutil.Equals(t, got, ent)
+		_, ok = e.Get(types.NewEntityUID("Type", "id2"))
+		testutil.Equals(t, ok, false)
+	})
 }
 
 func TestEntitiesJSON(t *testing.T) {


### PR DESCRIPTION
This changes the `PolicySet` `IsAuthorized()` method to take an `EntityGetter` interface instead of a concrete `EntityMap` instance, allowing alternative entity getter implementations to be passed to the authorization.