### PR TITLE
Improve batch error handling

### DIFF
--- a/corpus_test.go
+++ b/corpus_test.go
@@ -208,9 +208,10 @@ func TestCorpus(t *testing.T) {
 							"resource":  []cedar.Value{resource},
 							"context":   []cedar.Value{context},
 						},
-					}, func(r batch.Result) {
+					}, func(r batch.Result) error {
 						res = r
 						total++
+						return nil
 					})
 					testutil.OK(t, err)
 					testutil.Equals(t, total, 1)

--- a/x/exp/batch/batch.go
+++ b/x/exp/batch/batch.go
@@ -71,7 +71,7 @@ type batchEvaler struct {
 	compiled bool
 	evalers  map[types.PolicyID]*idEvaler
 	env      eval.Env
-	callback func(Result) error
+	callback Callback
 }
 
 type variableItem struct {

--- a/x/exp/batch/batch.go
+++ b/x/exp/batch/batch.go
@@ -55,7 +55,7 @@ type Result struct {
 
 // Callback is a function that is called for each single batch authorization with
 // a Result.
-type Callback func(Result)
+type Callback func(Result) error
 
 type idEvaler struct {
 	Policy *ast.Policy
@@ -70,7 +70,7 @@ type batchEvaler struct {
 	compiled bool
 	evalers  map[types.PolicyID]*idEvaler
 	env      eval.Env
-	callback Callback
+	callback func(Result) error
 }
 
 type variableItem struct {
@@ -107,6 +107,7 @@ var errInvalidPart = fmt.Errorf("invalid part")
 //   - It will error in case any of PARC are an incorrect type at authorization.
 //   - It will error in case there are unbound variables.
 //   - It will error in case there are unused variables.
+//   - It will error in case of a callback error.
 //
 // The result passed to the callback must be used / cloned immediately and not modified.
 func Authorize(ctx context.Context, ps *cedar.PolicySet, entities types.EntityMap, request Request, cb Callback) error {
@@ -284,8 +285,7 @@ func diagnosticAuthzWithCallback(be *batchEvaler) error {
 	res.Values = be.Values
 	batchCompile(be)
 	res.Decision, res.Diagnostic = isAuthorized(be.evalers, be.env)
-	be.callback(res)
-	return nil
+	return be.callback(res)
 }
 
 func isAuthorized(ps map[types.PolicyID]*idEvaler, env eval.Env) (types.Decision, types.Diagnostic) {

--- a/x/exp/batch/batch.go
+++ b/x/exp/batch/batch.go
@@ -9,6 +9,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -175,7 +176,7 @@ func Authorize(ctx context.Context, ps *cedar.PolicySet, entities types.EntityMa
 		fixIgnores(be)
 	}
 
-	return doBatch(ctx, be)
+	return errors.Join(doBatch(ctx, be), ctx.Err())
 }
 
 func doPartial(be *batchEvaler) {

--- a/x/exp/batch/batch_test.go
+++ b/x/exp/batch/batch_test.go
@@ -422,6 +422,30 @@ func TestBatchErrors(t *testing.T) {
 		testutil.Equals(t, total, 2)
 	})
 
+	t.Run("contextAndCallbackErrored", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		errWant := fmt.Errorf("errWant")
+		err := Authorize(ctx, cedar.NewPolicySet(), types.EntityMap{}, Request{
+			Principal: types.NewEntityUID("Principal", "principal"),
+			Action:    types.NewEntityUID("Action", "action"),
+			Resource:  Variable("resource"),
+			Context:   types.Record{},
+			Variables: Variables{
+				"resource": []types.Value{
+					types.NewEntityUID("Resource", "1"),
+					types.NewEntityUID("Resource", "2"),
+					types.NewEntityUID("Resource", "3"),
+				},
+			},
+		}, func(_ Result) error {
+			cancel()
+			return errWant
+		},
+		)
+		testutil.ErrorIs(t, err, context.Canceled)
+		testutil.ErrorIs(t, err, errWant)
+	})
+
 	t.Run("invalidPrincipal", func(t *testing.T) {
 		err := Authorize(context.Background(), cedar.NewPolicySet(), types.EntityMap{}, Request{
 			Principal: types.String("invalid"),


### PR DESCRIPTION
This PR changes two things:

- Makes the error handling for context errors more consistent, it will return an error if you cancel in the last batch request.
- Adds an error to the batch callback signature.  Any error will cause the batch processing to cease and the error to be returned.


