### PR TITLE
Change batch Authorize() to take an EntityGetter in place of an EntityMap

### DIFF
--- a/types.go
+++ b/types.go
@@ -31,8 +31,8 @@ type String = types.String
 
 // Other Cedar types
 
-type EntityMap = types.EntityMap
 type Entity = types.Entity
+type EntityMap = types.EntityMap
 type EntityType = types.EntityType
 type EntityUIDSet = types.EntityUIDSet
 type Pattern = types.Pattern
@@ -40,6 +40,7 @@ type Wildcard = types.Wildcard
 
 // cedar-go types
 
+type EntityGetter = types.EntityGetter
 type Value = types.Value
 
 //   ____                _              _

--- a/x/exp/batch/batch.go
+++ b/x/exp/batch/batch.go
@@ -111,7 +111,7 @@ var errInvalidPart = fmt.Errorf("invalid part")
 //   - It will error in case of a callback error.
 //
 // The result passed to the callback must be used / cloned immediately and not modified.
-func Authorize(ctx context.Context, ps *cedar.PolicySet, entities types.EntityMap, request Request, cb Callback) error {
+func Authorize(ctx context.Context, ps *cedar.PolicySet, entities types.EntityGetter, request Request, cb Callback) error {
 	be := &batchEvaler{}
 	var found mapset.MapSet[types.String]
 	findVariables(&found, request.Principal)

--- a/x/exp/batch/batch_test.go
+++ b/x/exp/batch/batch_test.go
@@ -25,7 +25,7 @@ func TestBatch(t *testing.T) {
 	tests := []struct {
 		name     string
 		policy   *ast.Policy
-		entities types.EntityMap
+		entities types.EntityGetter
 		request  Request
 		results  []Result
 	}{


### PR DESCRIPTION
This changes the x/exp/batch package's `Authorize()` to take an `EntityGetter` interface in place of a concrete `EntityMap`, to align this with the `PolicySet.IsAuthorized()` signature.