### PR TITLE
Addresses cedar-policy/rfcs#94 concerns about time wrapping

### DIFF
--- a/types/datetime.go
+++ b/types/datetime.go
@@ -200,6 +200,18 @@ func ParseDatetime(s string) (Datetime, error) {
 	t := time.Date(year, time.Month(month), day,
 		hour, minute, second,
 		int(time.Duration(milli)*time.Millisecond), time.UTC)
+
+	// Don't allow wrapping: https://github.com/cedar-policy/rfcs/pull/94
+	tyear, tmonth, tday := t.Date()
+	if year != tyear || time.Month(month) != tmonth || day != tday {
+		return Datetime{}, fmt.Errorf("%w: date would wrap", errDatetime)
+	}
+
+	thour, tminute, tsecond := t.Hour(), t.Minute(), t.Second()
+	if hour != thour || minute != tminute || second != tsecond {
+		return Datetime{}, fmt.Errorf("%w: time would wrap", errDatetime)
+	}
+
 	t = t.Add(offset)
 	return Datetime{value: t.UnixMilli()}, nil
 }

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -102,15 +102,18 @@ func TestDatetime(t *testing.T) {
 			{"1995-01-01T00:00:00.000-aaaa0", "error parsing datetime value: unexpected trailer after time zone designator"},
 
 			// Prevent Wrapping invalid dates to real dates: See: cedar-policy/rfcs#94
-			{"2024-02-30T00:00:00Z", "error parsing datetime value: date would wrap"},
-			{"2024-02-29T23:59:60Z", "error parsing datetime value: date would wrap"},
-			{"2023-02-28T23:59:60Z", "error parsing datetime value: date would wrap"},
-			{"1970-01-01T25:00:00Z", "error parsing datetime value: date would wrap"},
-			{"1970-01-32T00:00:00Z", "error parsing datetime value: date would wrap"},
-			{"1970-13-01T00:00:00Z", "error parsing datetime value: date would wrap"},
+			{"2024-02-30T00:00:00Z", "error parsing datetime value: invalid date"},
+			{"2024-02-29T23:59:60Z", "error parsing datetime value: second is out of range"},
+			{"2023-02-28T23:59:60Z", "error parsing datetime value: second is out of range"},
+			{"2023-02-28T23:60:59Z", "error parsing datetime value: minute is out of range"},
+			{"1970-01-01T25:00:00Z", "error parsing datetime value: hour is out of range"},
+			{"1970-12-32T:00:00Z", "error parsing datetime value: day is out of range"},
+			{"1970-13-01T00:00:00Z", "error parsing datetime value: month is out of range"},
 
-			{"1970-01-01T00:00:60Z", "error parsing datetime value: time would wrap"},
-			{"1970-01-01T00:60:00Z", "error parsing datetime value: time would wrap"},
+			{"1970-01-01T00:00:00+2400", "error parsing datetime value: time zone offset hours are out of range"},
+			{"1970-01-01T00:00:00-2400", "error parsing datetime value: time zone offset hours are out of range"},
+			{"1970-01-01T00:00:00+2360", "error parsing datetime value: time zone offset minutes are out of range"},
+			{"1970-01-01T00:00:00-2360", "error parsing datetime value: time zone offset minutes are out of range"},
 		}
 		for ti, tt := range tests {
 			tt := tt

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -100,6 +100,17 @@ func TestDatetime(t *testing.T) {
 			{"1995-01-01T00:00:00.000-0aaa", "error parsing datetime value: invalid time zone offset"},
 			{"1995-01-01T00:00:00.000-aaaa", "error parsing datetime value: invalid time zone offset"},
 			{"1995-01-01T00:00:00.000-aaaa0", "error parsing datetime value: unexpected trailer after time zone designator"},
+
+			// Prevent Wrapping invalid dates to real dates: See: cedar-policy/rfcs#94
+			{"2024-02-30T00:00:00Z", "error parsing datetime value: date would wrap"},
+			{"2024-02-29T23:59:60Z", "error parsing datetime value: date would wrap"},
+			{"2023-02-28T23:59:60Z", "error parsing datetime value: date would wrap"},
+			{"1970-01-01T25:00:00Z", "error parsing datetime value: date would wrap"},
+			{"1970-01-32T00:00:00Z", "error parsing datetime value: date would wrap"},
+			{"1970-13-01T00:00:00Z", "error parsing datetime value: date would wrap"},
+
+			{"1970-01-01T00:00:60Z", "error parsing datetime value: time would wrap"},
+			{"1970-01-01T00:60:00Z", "error parsing datetime value: time would wrap"},
 		}
 		for ti, tt := range tests {
 			tt := tt

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -42,6 +42,8 @@ func TestDatetime(t *testing.T) {
 			{"1970-01-01T00:10:00-0010", "1970-01-01T00:00:00.000Z"},
 			{"1970-01-01T01:00:00-0100", "1970-01-01T00:00:00.000Z"},
 			{"1970-01-01T10:00:00-1000", "1970-01-01T00:00:00.000Z"},
+
+			{"1972-02-29T10:00:00-1000", "1972-02-29T00:00:00.000Z"},
 		}
 		for ti, tt := range tests {
 			tt := tt
@@ -100,6 +102,8 @@ func TestDatetime(t *testing.T) {
 			{"1995-01-01T00:00:00.000-0aaa", "error parsing datetime value: invalid time zone offset"},
 			{"1995-01-01T00:00:00.000-aaaa", "error parsing datetime value: invalid time zone offset"},
 			{"1995-01-01T00:00:00.000-aaaa0", "error parsing datetime value: unexpected trailer after time zone designator"},
+
+			{"1995-04-31T00:00:00Z", "error parsing datetime value: invalid date"},
 
 			// Prevent Wrapping invalid dates to real dates: See: cedar-policy/rfcs#94
 			{"2024-02-30T00:00:00Z", "error parsing datetime value: invalid date"},


### PR DESCRIPTION
The Go time package will silently ignore dates that don't exist on the calendar, instead carrying forward the erroneous time component. As an example, `2024-02-30` will become `2024-03-01`, since there was no February 30th, in 2024 (or ever).

This change returns an error when there's a discrepancy between the numbers we parse from the string, and the component after creating a Go time.Time value from the parsed numbers.

*Issue https://github.com/cedar-policy/rfcs/issues/94*



