### PR TITLE
cedar-go: upgrade golangci-lint checks to v2 and fix all issues found

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,34 +19,4 @@ jobs:
           go-version: "1.22"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          # Require: The version of golangci-lint to use.
-          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
-          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.56.2
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          #
-          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
-          # The location of the configuration file can be changed by using `--config=`
-          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true, then all caching functionality will be completely disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
-
-          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
-          # install-mode: "goinstall"
+        uses: golangci/golangci-lint-action@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,218 +1,34 @@
-run:
-  build-tags:
-  - dev
-  timeout: 10m
-  go: 1.22
-
+version: "2"
 linters:
-  disable-all: true
   enable:
-  - bodyclose
-  - errcheck
-  - errname
-  - gofmt
-  - goimports
-  - govet
-  - ineffassign
-  - staticcheck
-  - unused
-  - revive
-
-issues:
-  max-issues-per-linter: 100
-  max-same-issues: 100
-  exclude-rules:
-  # Exclude some linters from running on tests files.
-  - path: _test\.go
-    linters:
-    - bodyclose
-
-linters-settings:
-  staticcheck:
-    # Disabled checks:
-    # - SA1019: Using a deprecated function, variable, constant or field
-    # - SA9003: Empty body in an if or else branch
-    checks: ["all", "-SA1019", "-SA9003"]
-  revive:
+    - errcheck
+    - errname
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+  exclusions:
     rules:
-    - name: add-constant
-      disabled: true
-    - name: atomic
-      disabled: false
-      severity: error
-    - name: argument-limit
-      disabled: false
-    - name: banned-characters
-      disabled: false
-      severity: error
-    - name: bare-return
-      disabled: true
-    - name: blank-imports
-      disabled: false
-      severity: error
-    - name: bool-literal-in-expr
-      disabled: false
-    - name: call-to-gc
-      disabled: false
-    - name: cognitive-complexity # revisit periodically - exclude tests
-      disabled: false
-      arguments: [65] # emprically set to upper bound
-    - name: comment-spacings
-      disabled: false
-    - name: confusing-naming # too opinionated
-      disabled: true
-    - name: confusing-results
-      disabled: false
-    - name: constant-logical-expr
-      disabled: false
-      severity: error
-    - name: context-as-argument
-      disabled: false
-    - name: context-keys-type
-      disabled: false
-    - name: cyclomatic # revisit - exclude tests
-      disabled: false
-      arguments: [92] # emprically set to upper bound
-    - name: datarace
-      disabled: false
-      severity: error
-    - name: deep-exit
-      disabled: false
-    - name: defer # often wrong
-      disabled: false
-    - name: dot-imports
-      disabled: false
-      severity: error
-    - name: duplicated-imports
-      disabled: false
-      severity: error
-    - name: early-return
-      disabled: false
-    - name: empty-block
-      disabled: false
-    - name: empty-lines # maybe correct but annoying
-      disabled: true
-    - name: enforce-map-style
-      disabled: false
-      severity: error
-    - name: enforce-slice-style
-      disabled: false
-      severity: error
-    - name: errorf
-      disabled: false
-      severity: error
-    - name: error-naming
-      disabled: false
-      severity: error
-    - name: error-return # fine, but unnecessarily picky
-      disabled: false
-    - name: error-strings # fine, but unnecessarily picky
-      disabled: false
-    - name: exported # possibly too opinionated
-      disabled: false
-    - name: file-header
-      disabled: false
-      severity: error
-    - name: flag-parameter # often wrong
-      disabled: true
-    - name: function-length # revisit - exclude tests
-      disabled: false
-      arguments: [136, 702] # emprically set to upper bound
-    - name: function-result-limit
-      disabled: false
-    - name: get-return
-      disabled: false
-    - name: identical-branches
-      disabled: false
-      severity: error
-    - name: if-return # reasonable candidate but too opinonated
-      disabled: false
-    - name: import-alias-naming
-      disabled: false
-    - name: import-shadowing # sounds nice, but too many good variable names are taken up by packages.
-      disabled: false
-    - name: increment-decrement # just style
-      disabled: false
-    - name: indent-error-flow # fine, but unnecessarily picky
-      disabled: true
-    - name: line-length-limit
-      disabled: true
-    - name: max-public-structs # too opinionated
-      disabled: true
-    - name: modifies-parameter
-      disabled: false
-      severity: error
-    - name: modifies-value-receiver
-      disabled: false
-      severity: error
-    - name: nested-structs # deliberately used in some places
-      disabled: true
-    - name: optimize-operands-order
-      disabled: false
-      severity: error
-    - name: package-comments
-      disabled: false
-      severity: error
-    - name: range
-      disabled: false
-      severity: error
-    - name: range-val-address
-      disabled: false
-      severity: error
-    - name: range-val-in-closure
-      disabled: false
-      severity: error
-    - name: receiver-naming # unnecessarily picky
-      disabled: true
-    - name: redefines-builtin-id # useful 
-      disabled: false
-    - name: redundant-import-alias
-      disabled: false
-    - name: string-of-int
-      disabled: false
-      severity: error
-    - name: string-format
-      disabled: false
-      severity: error
-    - name: struct-tag # often wrong
-      disabled: false
-    - name: superfluous-else
-      disabled: false
-      severity: error
-    - name: time-equal
-      disabled: false
-      severity: error
-    - name: time-naming
-      disabled: false
-    - name: unchecked-type-assertion # a panic here is sometimes correct as a programming error
-      disabled: false
-    - name: unconditional-recursion
-      disabled: false
-      severity: error
-    - name: unexported-naming
-      disabled: false
-      severity: error
-    - name: unexported-return
-      disabled: false
-    - name: unhandled-error # complains about e.g. fmt.Println
-      disabled: true
-    - name: unnecessary-stmt # opinionated
-      disabled: false
-    - name: unreachable-code
-      disabled: false
-      severity: error
-    - name: unused-parameter
-      disabled: false
-    - name: unused-receiver # too picky
-      disabled: true
-    - name: useless-break
-      disabled: false
-    - name: use-any # opinionated
-      disabled: true
-    - name: var-declaration # too picky
-      disabled: false
-    - name: var-naming # incompatible with this codebase
-      disabled: true
-    - name: waitgroup-by-value
-      disabled: false
-      severity: error
+      # Legitimate exclusion - we don't need to thoroughly document internal types
+      - path: internal/
+        linters:
+          - revive
+        text: exported
+
+      # Legitimate exclusion - we don't need to thoroughly document unstable interfaces
+      - path: x/
+        linters:
+          - revive
+        text: exported
+
+      # Legitimate exclusion - we don't need to thoroughly document internal packages
+      - path: internal/
+        linters:
+          - revive
+        text: package-comments
+
+      # We will make an effort to remove this exclusion
+      - path: types/
+        linters:
+          - revive
+        text: exported

--- a/ast/annotation.go
+++ b/ast/annotation.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cedar-policy/cedar-go/x/exp/ast"
 )
 
+// Annotations allows access to Cedar annotations on a policy
 type Annotations ast.Annotations
 
 func (a *Annotations) unwrap() *ast.Annotations {
@@ -41,7 +42,8 @@ func (a *Annotations) Forbid() *Policy {
 	return wrapPolicy(a.unwrap().Forbid())
 }
 
-// If a previous annotation exists with the same key, this builder will replace it.
+// Annotate adds an annotation to a Policy. If a previous annotation exists with the same key, this builder will
+// replace it.
 func (p *Policy) Annotate(key types.Ident, value types.String) *Policy {
 	return wrapPolicy(p.unwrap().Annotate(key, value))
 }

--- a/ast/operator.go
+++ b/ast/operator.go
@@ -12,46 +12,57 @@ import (
 //  \____\___/|_| |_| |_| .__/ \__,_|_|  |_|___/\___/|_| |_|
 //                      |_|
 
+// Equal builds an AST node representing the = operator
 func (lhs Node) Equal(rhs Node) Node {
 	return wrapNode(lhs.Node.Equal(rhs.Node))
 }
 
+// NotEqual builds an AST node representing the != operator
 func (lhs Node) NotEqual(rhs Node) Node {
 	return wrapNode(lhs.Node.NotEqual(rhs.Node))
 }
 
+// LessThan builds an AST node representing the < operator
 func (lhs Node) LessThan(rhs Node) Node {
 	return wrapNode(lhs.Node.LessThan(rhs.Node))
 }
 
+// LessThanOrEqual builds an AST node representing the <= operator
 func (lhs Node) LessThanOrEqual(rhs Node) Node {
 	return wrapNode(lhs.Node.LessThanOrEqual(rhs.Node))
 }
 
+// GreaterThan builds an AST node representing the > operator
 func (lhs Node) GreaterThan(rhs Node) Node {
 	return wrapNode(lhs.Node.GreaterThan(rhs.Node))
 }
 
+// GreaterThanOrEqual builds an AST node representing the >= operator
 func (lhs Node) GreaterThanOrEqual(rhs Node) Node {
 	return wrapNode(lhs.Node.GreaterThanOrEqual(rhs.Node))
 }
 
+// DecimalLessThan builds an AST node representing the .lessThan() operator
 func (lhs Node) DecimalLessThan(rhs Node) Node {
 	return wrapNode(lhs.Node.DecimalLessThan(rhs.Node))
 }
 
+// DecimalLessThanOrEqual builds an AST node representing the .lessThanOrEqual() operator
 func (lhs Node) DecimalLessThanOrEqual(rhs Node) Node {
 	return wrapNode(lhs.Node.DecimalLessThanOrEqual(rhs.Node))
 }
 
+// DecimalGreaterThan builds an AST node representing the .greaterThan() operator
 func (lhs Node) DecimalGreaterThan(rhs Node) Node {
 	return wrapNode(lhs.Node.DecimalGreaterThan(rhs.Node))
 }
 
+// DecimalGreaterThanOrEqual builds an AST node representing the .greaterThanOrEqual() operator
 func (lhs Node) DecimalGreaterThanOrEqual(rhs Node) Node {
 	return wrapNode(lhs.Node.DecimalGreaterThanOrEqual(rhs.Node))
 }
 
+// Like builds an AST node representing the like operator
 func (lhs Node) Like(pattern types.Pattern) Node {
 	return wrapNode(lhs.Node.Like(pattern))
 }
@@ -63,18 +74,22 @@ func (lhs Node) Like(pattern types.Pattern) Node {
 // |_____\___/ \__, |_|\___\__,_|_|
 //             |___/
 
+// And builds an AST node representing the && operator
 func (lhs Node) And(rhs Node) Node {
 	return wrapNode(lhs.Node.And(rhs.Node))
 }
 
+// Or builds an AST node representing the || operator
 func (lhs Node) Or(rhs Node) Node {
 	return wrapNode(lhs.Node.Or(rhs.Node))
 }
 
+// Not builds an AST node representing the ! operator
 func Not(rhs Node) Node {
 	return wrapNode(ast.Not(rhs.Node))
 }
 
+// IfThenElse builds an AST node representing the if (CONDITIONAL) operator
 func IfThenElse(condition Node, thenNode Node, elseNode Node) Node {
 	return wrapNode(ast.IfThenElse(condition.Node, thenNode.Node, elseNode.Node))
 }
@@ -85,18 +100,22 @@ func IfThenElse(condition Node, thenNode Node, elseNode Node) Node {
 //  / ___ \| |  | | |_| | | | | | | | |  __/ |_| | (__
 // /_/   \_\_|  |_|\__|_| |_|_| |_| |_|\___|\__|_|\___|
 
+// Add builds an AST node representing the + operator
 func (lhs Node) Add(rhs Node) Node {
 	return wrapNode(lhs.Node.Add(rhs.Node))
 }
 
+// Subtract builds an AST node representing the - operator
 func (lhs Node) Subtract(rhs Node) Node {
 	return wrapNode(lhs.Node.Subtract(rhs.Node))
 }
 
+// Multiply builds an AST node representing the * operator
 func (lhs Node) Multiply(rhs Node) Node {
 	return wrapNode(lhs.Node.Multiply(rhs.Node))
 }
 
+// Negate builds an AST node representing the ! operator
 func Negate(rhs Node) Node {
 	return wrapNode(ast.Negate(rhs.Node))
 }
@@ -108,44 +127,55 @@ func Negate(rhs Node) Node {
 // |_| |_|_|\___|_|  \__,_|_|  \___|_| |_|\__, |
 //                                        |___/
 
+// In builds an AST node representing the in operator
 func (lhs Node) In(rhs Node) Node {
 	return wrapNode(lhs.Node.In(rhs.Node))
 }
 
+// Is builds an AST node representing the is operator
 func (lhs Node) Is(entityType types.EntityType) Node {
 	return wrapNode(lhs.Node.Is(entityType))
 }
 
+// IsIn builds an AST node representing the "is in" operator
 func (lhs Node) IsIn(entityType types.EntityType, rhs Node) Node {
 	return wrapNode(lhs.Node.IsIn(entityType, rhs.Node))
 }
 
+// Contains builds an AST node representing the .contains() operator
 func (lhs Node) Contains(rhs Node) Node {
 	return wrapNode(lhs.Node.Contains(rhs.Node))
 }
 
+// ContainsAll builds an AST node representing the .containsAll() operator
 func (lhs Node) ContainsAll(rhs Node) Node {
 	return wrapNode(lhs.Node.ContainsAll(rhs.Node))
 }
 
+// ContainsAny builds an AST node representing the .containsAny() operator
 func (lhs Node) ContainsAny(rhs Node) Node {
 	return wrapNode(lhs.Node.ContainsAny(rhs.Node))
 }
 
+// IsEmpty builds an AST node representing the .isEmpty() operator
 func (lhs Node) IsEmpty() Node { return wrapNode(lhs.Node.IsEmpty()) }
 
+// Access builds an AST node representing the . and [] operators to access entity attributes
 func (lhs Node) Access(attr types.String) Node {
 	return wrapNode(lhs.Node.Access(attr))
 }
 
+// Has builds an AST node representing the has operator
 func (lhs Node) Has(attr types.String) Node {
 	return wrapNode(lhs.Node.Has(attr))
 }
 
+// GetTag builds an AST node representing the .getTag() operator
 func (lhs Node) GetTag(rhs Node) Node {
 	return wrapNode(lhs.Node.GetTag(rhs.Node))
 }
 
+// HasTag builds an AST node representing the .hasTag() operator
 func (lhs Node) HasTag(rhs Node) Node {
 	return wrapNode(lhs.Node.HasTag(rhs.Node))
 }
@@ -156,22 +186,27 @@ func (lhs Node) HasTag(rhs Node) Node {
 //  | ||  __/ ___ \ (_| | (_| | | |  __/\__ \__ \
 // |___|_| /_/   \_\__,_|\__,_|_|  \___||___/___/
 
+// IsIpv4 builds an AST node representing the .isIpv4() operator
 func (lhs Node) IsIpv4() Node {
 	return wrapNode(lhs.Node.IsIpv4())
 }
 
+// IsIpv6 builds an AST node representing the .isIpv6() operator
 func (lhs Node) IsIpv6() Node {
 	return wrapNode(lhs.Node.IsIpv6())
 }
 
+// IsMulticast builds an AST node representing the .isMulticast() operator
 func (lhs Node) IsMulticast() Node {
 	return wrapNode(lhs.Node.IsMulticast())
 }
 
+// IsLoopback builds an AST node representing the .isLoopback() operator
 func (lhs Node) IsLoopback() Node {
 	return wrapNode(lhs.Node.IsLoopback())
 }
 
+// IsInRange builds an AST node representing the .isInRange() operator
 func (lhs Node) IsInRange(rhs Node) Node {
 	return wrapNode(lhs.Node.IsInRange(rhs.Node))
 }
@@ -182,12 +217,16 @@ func (lhs Node) IsInRange(rhs Node) Node {
 // | |_| | (_| | ||  __/ |_| | | | | | |  __/
 // |____/ \__,_|\__\___|\__|_|_| |_| |_|\___|
 
+// Offset builds an AST node representing the .offset() operator
 func (lhs Node) Offset(rhs Node) Node { return wrapNode(lhs.Node.Offset(rhs.Node)) }
 
+// DurationSince builds an AST node representing the .durationSince() operator
 func (lhs Node) DurationSince(rhs Node) Node { return wrapNode(lhs.Node.DurationSince(rhs.Node)) }
 
+// ToDate builds an AST node representing the .toDate() operator
 func (lhs Node) ToDate() Node { return wrapNode(lhs.Node.ToDate()) }
 
+// ToTime builds an AST node representing the .toTime() operator
 func (lhs Node) ToTime() Node { return wrapNode(lhs.Node.ToTime()) }
 
 //  ____                  _   _
@@ -196,12 +235,17 @@ func (lhs Node) ToTime() Node { return wrapNode(lhs.Node.ToTime()) }
 // | |_| | |_| | | | (_| | |_| | (_) | | | |
 // |____/ \__,_|_|  \__,_|\__|_|\___/|_| |_|
 
+// ToDays builds an AST node representing the .toDays() operator
 func (lhs Node) ToDays() Node { return wrapNode(lhs.Node.ToDays()) }
 
+// ToHours builds an AST node representing the .toHours() operator
 func (lhs Node) ToHours() Node { return wrapNode(lhs.Node.ToHours()) }
 
+// ToMinutes builds an AST node representing the .toMinutes() operator
 func (lhs Node) ToMinutes() Node { return wrapNode(lhs.Node.ToMinutes()) }
 
+// ToSeconds builds an AST node representing the .toSeconds() operator
 func (lhs Node) ToSeconds() Node { return wrapNode(lhs.Node.ToSeconds()) }
 
+// ToMilliseconds builds an AST node representing the .toMilliseconds() operator
 func (lhs Node) ToMilliseconds() Node { return wrapNode(lhs.Node.ToMilliseconds()) }

--- a/ast/policy.go
+++ b/ast/policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cedar-policy/cedar-go/x/exp/ast"
 )
 
+// Policy represents a single Cedar policy statement
 type Policy ast.Policy
 
 func wrapPolicy(p *ast.Policy) *Policy {

--- a/ast/value.go
+++ b/ast/value.go
@@ -59,6 +59,7 @@ type Pair struct {
 	Value Node
 }
 
+// Pairs is a slice of Pair elements
 type Pairs []Pair
 
 // Record creates a record node.  In the case where duplicate keys exist, the latter value will be preserved.
@@ -75,15 +76,17 @@ func EntityUID(typ types.Ident, id types.String) Node {
 	return wrapNode(ast.EntityUID(typ, id))
 }
 
-// IPAddr creates an value node containing an IPAddr.
+// IPAddr creates a value node containing an IPAddr.
 func IPAddr[T netip.Prefix | types.IPAddr](i T) Node {
 	return wrapNode(ast.IPAddr(types.IPAddr(i)))
 }
 
+// Datetime creates a value node containing a timestamp
 func Datetime(t time.Time) Node {
 	return Value(types.NewDatetime(t))
 }
 
+// Duration creates a value node containing a duration
 func Duration(d time.Duration) Node {
 	return Value(types.NewDuration(d))
 }

--- a/ast/variable.go
+++ b/ast/variable.go
@@ -2,18 +2,22 @@ package ast
 
 import "github.com/cedar-policy/cedar-go/x/exp/ast"
 
+// Principal represents the principal in the request
 func Principal() Node {
 	return wrapNode(ast.Principal())
 }
 
+// Action represents the action in the request
 func Action() Node {
 	return wrapNode(ast.Action())
 }
 
+// Resource represents the resource in the request
 func Resource() Node {
 	return wrapNode(ast.Resource())
 }
 
+// Context represents the context in the request
 func Context() Node {
 	return wrapNode(ast.Context())
 }

--- a/authorize.go
+++ b/authorize.go
@@ -5,6 +5,8 @@ import (
 	"github.com/cedar-policy/cedar-go/types"
 )
 
+//revive:disable:exported
+
 type Request = types.Request
 type Decision = types.Decision
 type Diagnostic = types.Diagnostic
@@ -15,6 +17,8 @@ const (
 	Allow = types.Allow
 	Deny  = types.Deny
 )
+
+//revive:enable:exported
 
 // IsAuthorized uses the combination of the PolicySet and Entities to determine
 // if the given Request to determine Decision and Diagnostic.

--- a/corpus_test.go
+++ b/corpus_test.go
@@ -98,7 +98,7 @@ func TestCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal("error reading corpus compressed archive header", err)
 	}
-	defer gzipReader.Close()
+	defer gzipReader.Close() //nolint:errcheck
 
 	buf, err := io.ReadAll(gzipReader)
 	if err != nil {

--- a/internal/eval/evalers.go
+++ b/internal/eval/evalers.go
@@ -532,28 +532,28 @@ func (n *decimalGreaterThanOrEqualEval) Eval(env Env) (types.Value, error) {
 
 // ifThenElseEval
 type ifThenElseEval struct {
-	if_   Evaler
-	then  Evaler
-	else_ Evaler
+	ifNode   Evaler
+	thenNode Evaler
+	elseNode Evaler
 }
 
-func newIfThenElseEval(if_, then, else_ Evaler) *ifThenElseEval {
+func newIfThenElseEval(ifNode, thenNode, elseNode Evaler) *ifThenElseEval {
 	return &ifThenElseEval{
-		if_:   if_,
-		then:  then,
-		else_: else_,
+		ifNode:   ifNode,
+		thenNode: thenNode,
+		elseNode: elseNode,
 	}
 }
 
 func (n *ifThenElseEval) Eval(env Env) (types.Value, error) {
-	cond, err := evalBool(n.if_, env)
+	cond, err := evalBool(n.ifNode, env)
 	if err != nil {
 		return zeroValue(), err
 	}
 	if cond {
-		return n.then.Eval(env)
+		return n.thenNode.Eval(env)
 	}
-	return n.else_.Eval(env)
+	return n.elseNode.Eval(env)
 }
 
 // notEqualNode
@@ -1227,54 +1227,54 @@ func newExtensionEval(name types.Path, args []Evaler) Evaler {
 		if i.Args != len(args) {
 			return newErrorEval(fmt.Errorf("%w: %s takes %d parameter(s), but %d provided", errArity, name, i.Args, len(args)))
 		}
-		switch {
-		case name == "datetime":
+		switch name {
+		case "datetime":
 			return newDatetimeLiteralEval(args[0])
-		case name == "decimal":
+		case "decimal":
 			return newDecimalLiteralEval(args[0])
-		case name == "duration":
+		case "duration":
 			return newDurationLiteralEval(args[0])
-		case name == "ip":
+		case "ip":
 			return newIPLiteralEval(args[0])
 
-		case name == "lessThan":
+		case "lessThan":
 			return newDecimalLessThanEval(args[0], args[1])
-		case name == "lessThanOrEqual":
+		case "lessThanOrEqual":
 			return newDecimalLessThanOrEqualEval(args[0], args[1])
-		case name == "greaterThan":
+		case "greaterThan":
 			return newDecimalGreaterThanEval(args[0], args[1])
-		case name == "greaterThanOrEqual":
+		case "greaterThanOrEqual":
 			return newDecimalGreaterThanOrEqualEval(args[0], args[1])
 
-		case name == "isIpv4":
+		case "isIpv4":
 			return newIPTestEval(args[0], ipTestIPv4)
-		case name == "isIpv6":
+		case "isIpv6":
 			return newIPTestEval(args[0], ipTestIPv6)
-		case name == "isLoopback":
+		case "isLoopback":
 			return newIPTestEval(args[0], ipTestLoopback)
-		case name == "isMulticast":
+		case "isMulticast":
 			return newIPTestEval(args[0], ipTestMulticast)
-		case name == "isInRange":
+		case "isInRange":
 			return newIPIsInRangeEval(args[0], args[1])
 
-		case name == "toDate":
+		case "toDate":
 			return newToDateEval(args[0])
-		case name == "toTime":
+		case "toTime":
 			return newToTimeEval(args[0])
-		case name == "toMilliseconds":
+		case "toMilliseconds":
 			return newToMillisecondsEval(args[0])
-		case name == "toSeconds":
+		case "toSeconds":
 			return newToSecondsEval(args[0])
-		case name == "toMinutes":
+		case "toMinutes":
 			return newToMinutesEval(args[0])
-		case name == "toHours":
+		case "toHours":
 			return newToHoursEval(args[0])
-		case name == "toDays":
+		case "toDays":
 			return newToDaysEval(args[0])
 
-		case name == "offset":
+		case "offset":
 			return newOffsetEval(args[0], args[1])
-		case name == "durationSince":
+		case "durationSince":
 			return newDurationSinceEval(args[0], args[1])
 		}
 	}

--- a/internal/eval/partial.go
+++ b/internal/eval/partial.go
@@ -423,31 +423,31 @@ func isFalse(in ast.IsNode) bool {
 }
 
 func partialIfThenElse(env Env, v ast.NodeTypeIfThenElse) (ast.IsNode, error) {
-	if_, ifErr := partial(env, v.If)
+	ifNode, ifErr := partial(env, v.If)
 	switch {
 	case errors.Is(ifErr, errVariable):
 	case ifErr != nil:
 		return nil, ifErr
-	case isNonBoolValue(if_):
+	case isNonBoolValue(ifNode):
 		return nil, fmt.Errorf("%w: ifThenElse expected bool", ErrType)
-	case isTrue(if_):
+	case isTrue(ifNode):
 		return partial(env, v.Then)
-	case isFalse(if_):
+	case isFalse(ifNode):
 		return partial(env, v.Else)
 	}
-	then, thenErr := partial(env, v.Then)
+	thenNode, thenErr := partial(env, v.Then)
 	if errors.Is(thenErr, errIgnore) {
 		return nil, thenErr
 	} else if thenErr != nil && !errors.Is(thenErr, errVariable) {
-		then = extError(thenErr)
+		thenNode = extError(thenErr)
 	}
-	else_, elseErr := partial(env, v.Else)
+	elseNode, elseErr := partial(env, v.Else)
 	if errors.Is(elseErr, errIgnore) {
 		return nil, elseErr
 	} else if elseErr != nil && !errors.Is(elseErr, errVariable) {
-		else_ = extError(elseErr)
+		elseNode = extError(elseErr)
 	}
-	return ast.NodeTypeIfThenElse{If: if_, Then: then, Else: else_}, nil
+	return ast.NodeTypeIfThenElse{If: ifNode, Then: thenNode, Else: elseNode}, nil
 }
 
 func partialAnd(env Env, v ast.NodeTypeAnd) (ast.IsNode, error) {

--- a/internal/eval/util_test.go
+++ b/internal/eval/util_test.go
@@ -88,9 +88,9 @@ func TestUtil(t *testing.T) {
 				"foo": types.Boolean(true),
 				"bar": types.Long(1),
 			})
-			map_, err := ValueToRecord(v)
+			record, err := ValueToRecord(v)
 			testutil.OK(t, err)
-			v2 := map_
+			v2 := record
 			testutil.FatalIf(t, !v.Equal(v2), "got %v want %v", v, v2)
 		})
 

--- a/internal/json/json_marshal.go
+++ b/internal/json/json_marshal.go
@@ -136,7 +136,7 @@ func isInToJSON(dest **isJSON, src ast.NodeTypeIsIn) {
 	*dest = res
 }
 
-func (j *nodeJSON) FromNode(src ast.IsNode) {
+func (n *nodeJSON) FromNode(src ast.IsNode) {
 	switch t := src.(type) {
 	// Value
 	// Value *json.RawMessage `json:"Value"` // could be any
@@ -146,135 +146,135 @@ func (j *nodeJSON) FromNode(src ast.IsNode) {
 		// IP      arrayJSON `json:"ip"`
 		switch tt := t.Value.(type) {
 		case types.Decimal:
-			extToJSON(&j.ExtensionCall, "decimal", tt)
+			extToJSON(&n.ExtensionCall, "decimal", tt)
 			return
 		case types.IPAddr:
-			extToJSON(&j.ExtensionCall, "ip", tt)
+			extToJSON(&n.ExtensionCall, "ip", tt)
 			return
 		}
 		val := valueJSON{v: t.Value}
-		j.Value = &val
+		n.Value = &val
 		return
 
 	// Var
 	// Var *string `json:"Var"`
 	case ast.NodeTypeVariable:
 		val := string(t.Name)
-		j.Var = &val
+		n.Var = &val
 		return
 
 	// ! or neg operators
 	// Not    *unaryJSON `json:"!"`
 	// Negate *unaryJSON `json:"neg"`
 	case ast.NodeTypeNot:
-		unaryToJSON(&j.Not, t.UnaryNode)
+		unaryToJSON(&n.Not, t.UnaryNode)
 		return
 	case ast.NodeTypeNegate:
-		unaryToJSON(&j.Negate, t.UnaryNode)
+		unaryToJSON(&n.Negate, t.UnaryNode)
 		return
 
 	// Binary operators: ==, !=, in, <, <=, >, >=, &&, ||, +, -, *, contains, containsAll, containsAny, hasTag, getTag
 	case ast.NodeTypeAdd:
-		binaryToJSON(&j.Add, t.BinaryNode)
+		binaryToJSON(&n.Add, t.BinaryNode)
 		return
 	case ast.NodeTypeAnd:
-		binaryToJSON(&j.And, t.BinaryNode)
+		binaryToJSON(&n.And, t.BinaryNode)
 		return
 	case ast.NodeTypeContains:
-		binaryToJSON(&j.Contains, t.BinaryNode)
+		binaryToJSON(&n.Contains, t.BinaryNode)
 		return
 	case ast.NodeTypeContainsAll:
-		binaryToJSON(&j.ContainsAll, t.BinaryNode)
+		binaryToJSON(&n.ContainsAll, t.BinaryNode)
 		return
 	case ast.NodeTypeContainsAny:
-		binaryToJSON(&j.ContainsAny, t.BinaryNode)
+		binaryToJSON(&n.ContainsAny, t.BinaryNode)
 		return
 	case ast.NodeTypeIsEmpty:
-		unaryToJSON(&j.IsEmpty, t.UnaryNode)
+		unaryToJSON(&n.IsEmpty, t.UnaryNode)
 		return
 	case ast.NodeTypeEquals:
-		binaryToJSON(&j.Equals, t.BinaryNode)
+		binaryToJSON(&n.Equals, t.BinaryNode)
 		return
 	case ast.NodeTypeGreaterThan:
-		binaryToJSON(&j.GreaterThan, t.BinaryNode)
+		binaryToJSON(&n.GreaterThan, t.BinaryNode)
 		return
 	case ast.NodeTypeGreaterThanOrEqual:
-		binaryToJSON(&j.GreaterThanOrEqual, t.BinaryNode)
+		binaryToJSON(&n.GreaterThanOrEqual, t.BinaryNode)
 		return
 	case ast.NodeTypeIn:
-		binaryToJSON(&j.In, t.BinaryNode)
+		binaryToJSON(&n.In, t.BinaryNode)
 		return
 	case ast.NodeTypeLessThan:
-		binaryToJSON(&j.LessThan, t.BinaryNode)
+		binaryToJSON(&n.LessThan, t.BinaryNode)
 		return
 	case ast.NodeTypeLessThanOrEqual:
-		binaryToJSON(&j.LessThanOrEqual, t.BinaryNode)
+		binaryToJSON(&n.LessThanOrEqual, t.BinaryNode)
 		return
 	case ast.NodeTypeMult:
-		binaryToJSON(&j.Multiply, t.BinaryNode)
+		binaryToJSON(&n.Multiply, t.BinaryNode)
 		return
 	case ast.NodeTypeNotEquals:
-		binaryToJSON(&j.NotEquals, t.BinaryNode)
+		binaryToJSON(&n.NotEquals, t.BinaryNode)
 		return
 	case ast.NodeTypeOr:
-		binaryToJSON(&j.Or, t.BinaryNode)
+		binaryToJSON(&n.Or, t.BinaryNode)
 		return
 	case ast.NodeTypeSub:
-		binaryToJSON(&j.Subtract, t.BinaryNode)
+		binaryToJSON(&n.Subtract, t.BinaryNode)
 		return
 	case ast.NodeTypeGetTag:
-		binaryToJSON(&j.GetTag, t.BinaryNode)
+		binaryToJSON(&n.GetTag, t.BinaryNode)
 		return
 	case ast.NodeTypeHasTag:
-		binaryToJSON(&j.HasTag, t.BinaryNode)
+		binaryToJSON(&n.HasTag, t.BinaryNode)
 		return
 
 	// ., has
 	// Access *strJSON `json:"."`
 	// Has    *strJSON `json:"has"`
 	case ast.NodeTypeAccess:
-		strToJSON(&j.Access, t.StrOpNode)
+		strToJSON(&n.Access, t.StrOpNode)
 		return
 	case ast.NodeTypeHas:
-		strToJSON(&j.Has, t.StrOpNode)
+		strToJSON(&n.Has, t.StrOpNode)
 		return
 	// is
 	case ast.NodeTypeIs:
-		isToJSON(&j.Is, t)
+		isToJSON(&n.Is, t)
 		return
 	case ast.NodeTypeIsIn:
-		isInToJSON(&j.Is, t)
+		isInToJSON(&n.Is, t)
 		return
 
 	// like
 	// Like *strJSON `json:"like"`
 	case ast.NodeTypeLike:
-		likeToJSON(&j.Like, t)
+		likeToJSON(&n.Like, t)
 		return
 
 	// if-then-else
 	// IfThenElse *ifThenElseJSON `json:"if-then-else"`
 	case ast.NodeTypeIfThenElse:
-		ifToJSON(&j.IfThenElse, t)
+		ifToJSON(&n.IfThenElse, t)
 		return
 
 	// Set
 	// Set arrayJSON `json:"Set"`
 	case ast.NodeTypeSet:
-		arrayToJSON(&j.Set, t.Elements)
+		arrayToJSON(&n.Set, t.Elements)
 		return
 
 	// Record
 	// Record recordJSON `json:"Record"`
 	case ast.NodeTypeRecord:
-		recordToJSON(&j.Record, t)
+		recordToJSON(&n.Record, t)
 		return
 
 	// Any other method: ip, decimal, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
 	// ExtensionMethod map[string]arrayJSON `json:"-"`
 	case ast.NodeTypeExtensionCall:
-		j.ExtensionCall = extensionJSON{}
-		extCallToJSON(j.ExtensionCall, t)
+		n.ExtensionCall = extensionJSON{}
+		extCallToJSON(n.ExtensionCall, t)
 		return
 	default:
 		panic(fmt.Sprintf("unknown node type %T", t))
@@ -283,13 +283,13 @@ func (j *nodeJSON) FromNode(src ast.IsNode) {
 
 }
 
-func (j *nodeJSON) MarshalJSON() ([]byte, error) {
-	if len(j.ExtensionCall) > 0 {
-		return json.Marshal(j.ExtensionCall)
+func (n *nodeJSON) MarshalJSON() ([]byte, error) {
+	if len(n.ExtensionCall) > 0 {
+		return json.Marshal(n.ExtensionCall)
 	}
 
 	type nodeJSONAlias nodeJSON
-	return json.Marshal((*nodeJSONAlias)(j))
+	return json.Marshal((*nodeJSONAlias)(n))
 }
 
 type Policy ast.Policy

--- a/internal/json/json_unmarshal.go
+++ b/internal/json/json_unmarshal.go
@@ -110,19 +110,19 @@ func (j isJSON) ToNode() (ast.Node, error) {
 	return left.Is(types.EntityType(j.EntityType)), nil
 }
 func (j ifThenElseJSON) ToNode() (ast.Node, error) {
-	if_, err := j.If.ToNode()
+	ifNode, err := j.If.ToNode()
 	if err != nil {
 		return ast.Node{}, fmt.Errorf("error in if: %w", err)
 	}
-	then, err := j.Then.ToNode()
+	thenNode, err := j.Then.ToNode()
 	if err != nil {
 		return ast.Node{}, fmt.Errorf("error in then: %w", err)
 	}
-	else_, err := j.Else.ToNode()
+	elseNode, err := j.Else.ToNode()
 	if err != nil {
 		return ast.Node{}, fmt.Errorf("error in else: %w", err)
 	}
-	return ast.IfThenElse(if_, then, else_), nil
+	return ast.IfThenElse(ifNode, thenNode, elseNode), nil
 }
 func (j arrayJSON) ToNode() (ast.Node, error) {
 	var nodes []ast.Node
@@ -172,15 +172,15 @@ func (e extensionJSON) ToNode() (ast.Node, error) {
 	return ast.NewExtensionCall(types.Path(k), argNodes...), nil
 }
 
-func (j nodeJSON) ToNode() (ast.Node, error) {
+func (n nodeJSON) ToNode() (ast.Node, error) {
 	switch {
 	// Value
-	case j.Value != nil:
-		return ast.Value(j.Value.v), nil
+	case n.Value != nil:
+		return ast.Value(n.Value.v), nil
 
 	// Var
-	case j.Var != nil:
-		switch *j.Var {
+	case n.Var != nil:
+		switch *n.Var {
 		case consts.Principal:
 			return ast.Principal(), nil
 		case consts.Action:
@@ -190,84 +190,84 @@ func (j nodeJSON) ToNode() (ast.Node, error) {
 		case consts.Context:
 			return ast.Context(), nil
 		}
-		return ast.Node{}, fmt.Errorf("unknown variable: %v", j.Var)
+		return ast.Node{}, fmt.Errorf("unknown variable: %v", n.Var)
 
 	// Slot
 	// Unknown
 
 	// ! or neg operators
-	case j.Not != nil:
-		return j.Not.ToNode(ast.Not)
-	case j.Negate != nil:
-		return j.Negate.ToNode(ast.Negate)
+	case n.Not != nil:
+		return n.Not.ToNode(ast.Not)
+	case n.Negate != nil:
+		return n.Negate.ToNode(ast.Negate)
 
 	// Binary operators: ==, !=, in, <, <=, >, >=, &&, ||, +, -, *, contains, containsAll, containsAny, hasTag, getTag
-	case j.Equals != nil:
-		return j.Equals.ToNode(ast.Node.Equal)
-	case j.NotEquals != nil:
-		return j.NotEquals.ToNode(ast.Node.NotEqual)
-	case j.In != nil:
-		return j.In.ToNode(ast.Node.In)
-	case j.LessThan != nil:
-		return j.LessThan.ToNode(ast.Node.LessThan)
-	case j.LessThanOrEqual != nil:
-		return j.LessThanOrEqual.ToNode(ast.Node.LessThanOrEqual)
-	case j.GreaterThan != nil:
-		return j.GreaterThan.ToNode(ast.Node.GreaterThan)
-	case j.GreaterThanOrEqual != nil:
-		return j.GreaterThanOrEqual.ToNode(ast.Node.GreaterThanOrEqual)
-	case j.And != nil:
-		return j.And.ToNode(ast.Node.And)
-	case j.Or != nil:
-		return j.Or.ToNode(ast.Node.Or)
-	case j.Add != nil:
-		return j.Add.ToNode(ast.Node.Add)
-	case j.Subtract != nil:
-		return j.Subtract.ToNode(ast.Node.Subtract)
-	case j.Multiply != nil:
-		return j.Multiply.ToNode(ast.Node.Multiply)
-	case j.Contains != nil:
-		return j.Contains.ToNode(ast.Node.Contains)
-	case j.ContainsAll != nil:
-		return j.ContainsAll.ToNode(ast.Node.ContainsAll)
-	case j.ContainsAny != nil:
-		return j.ContainsAny.ToNode(ast.Node.ContainsAny)
-	case j.IsEmpty != nil:
-		return j.IsEmpty.ToNode(ast.Node.IsEmpty)
-	case j.GetTag != nil:
-		return j.GetTag.ToNode(ast.Node.GetTag)
-	case j.HasTag != nil:
-		return j.HasTag.ToNode(ast.Node.HasTag)
+	case n.Equals != nil:
+		return n.Equals.ToNode(ast.Node.Equal)
+	case n.NotEquals != nil:
+		return n.NotEquals.ToNode(ast.Node.NotEqual)
+	case n.In != nil:
+		return n.In.ToNode(ast.Node.In)
+	case n.LessThan != nil:
+		return n.LessThan.ToNode(ast.Node.LessThan)
+	case n.LessThanOrEqual != nil:
+		return n.LessThanOrEqual.ToNode(ast.Node.LessThanOrEqual)
+	case n.GreaterThan != nil:
+		return n.GreaterThan.ToNode(ast.Node.GreaterThan)
+	case n.GreaterThanOrEqual != nil:
+		return n.GreaterThanOrEqual.ToNode(ast.Node.GreaterThanOrEqual)
+	case n.And != nil:
+		return n.And.ToNode(ast.Node.And)
+	case n.Or != nil:
+		return n.Or.ToNode(ast.Node.Or)
+	case n.Add != nil:
+		return n.Add.ToNode(ast.Node.Add)
+	case n.Subtract != nil:
+		return n.Subtract.ToNode(ast.Node.Subtract)
+	case n.Multiply != nil:
+		return n.Multiply.ToNode(ast.Node.Multiply)
+	case n.Contains != nil:
+		return n.Contains.ToNode(ast.Node.Contains)
+	case n.ContainsAll != nil:
+		return n.ContainsAll.ToNode(ast.Node.ContainsAll)
+	case n.ContainsAny != nil:
+		return n.ContainsAny.ToNode(ast.Node.ContainsAny)
+	case n.IsEmpty != nil:
+		return n.IsEmpty.ToNode(ast.Node.IsEmpty)
+	case n.GetTag != nil:
+		return n.GetTag.ToNode(ast.Node.GetTag)
+	case n.HasTag != nil:
+		return n.HasTag.ToNode(ast.Node.HasTag)
 
 	// ., has
-	case j.Access != nil:
-		return j.Access.ToNode(ast.Node.Access)
-	case j.Has != nil:
-		return j.Has.ToNode(ast.Node.Has)
+	case n.Access != nil:
+		return n.Access.ToNode(ast.Node.Access)
+	case n.Has != nil:
+		return n.Has.ToNode(ast.Node.Has)
 
 	// is
-	case j.Is != nil:
-		return j.Is.ToNode()
+	case n.Is != nil:
+		return n.Is.ToNode()
 
 	// like
-	case j.Like != nil:
-		return j.Like.ToNode(ast.Node.Like)
+	case n.Like != nil:
+		return n.Like.ToNode(ast.Node.Like)
 
 	// if-then-else
-	case j.IfThenElse != nil:
-		return j.IfThenElse.ToNode()
+	case n.IfThenElse != nil:
+		return n.IfThenElse.ToNode()
 
 	// Set
-	case j.Set != nil:
-		return j.Set.ToNode()
+	case n.Set != nil:
+		return n.Set.ToNode()
 
 	// Record
-	case j.Record != nil:
-		return j.Record.ToNode()
+	case n.Record != nil:
+		return n.Record.ToNode()
 
 	// Any other method: lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
 	default:
-		return j.ExtensionCall.ToNode()
+		return n.ExtensionCall.ToNode()
 	}
 }
 

--- a/internal/parser/cedar_marshal.go
+++ b/internal/parser/cedar_marshal.go
@@ -99,7 +99,7 @@ func marshalEffect(e ast.Effect, buf *bytes.Buffer) {
 }
 
 func (n NodeTypeVariable) marshalCedar(buf *bytes.Buffer) {
-	buf.WriteString(string(n.NodeTypeVariable.Name))
+	buf.WriteString(string(n.Name))
 }
 
 func marshalCondition(c ast.ConditionType, buf *bytes.Buffer) {
@@ -115,7 +115,7 @@ func marshalCondition(c ast.ConditionType, buf *bytes.Buffer) {
 }
 
 func (n NodeValue) marshalCedar(buf *bytes.Buffer) {
-	buf.Write(n.NodeValue.Value.MarshalCedar())
+	buf.Write(n.Value.MarshalCedar())
 }
 
 func marshalChildNode(thisNodePrecedence nodePrecedenceLevel, childAstNode ast.IsNode, buf *bytes.Buffer) {
@@ -149,29 +149,29 @@ func canMarshalAsIdent(s string) bool {
 }
 
 func (n NodeTypeAccess) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeAccess.Arg, buf)
+	marshalChildNode(n.precedenceLevel(), n.Arg, buf)
 
-	if canMarshalAsIdent(string(n.NodeTypeAccess.Value)) {
+	if canMarshalAsIdent(string(n.Value)) {
 		buf.WriteRune('.')
-		buf.WriteString(string(n.NodeTypeAccess.Value))
+		buf.WriteString(string(n.Value))
 	} else {
 		buf.WriteRune('[')
-		buf.Write(n.NodeTypeAccess.Value.MarshalCedar())
+		buf.Write(n.Value.MarshalCedar())
 		buf.WriteRune(']')
 	}
 }
 
 func (n NodeTypeExtensionCall) marshalCedar(buf *bytes.Buffer) {
 	var args []ast.IsNode
-	info := extensions.ExtMap[n.NodeTypeExtensionCall.Name]
+	info := extensions.ExtMap[n.Name]
 	if info.IsMethod {
-		marshalChildNode(n.precedenceLevel(), n.NodeTypeExtensionCall.Args[0], buf)
+		marshalChildNode(n.precedenceLevel(), n.Args[0], buf)
 		buf.WriteRune('.')
-		args = n.NodeTypeExtensionCall.Args[1:]
+		args = n.Args[1:]
 	} else {
-		args = n.NodeTypeExtensionCall.Args
+		args = n.Args
 	}
-	buf.WriteString(string(n.NodeTypeExtensionCall.Name))
+	buf.WriteString(string(n.Name))
 	buf.WriteRune('(')
 	for i := range args {
 		marshalChildNode(n.precedenceLevel(), args[i], buf)
@@ -183,50 +183,50 @@ func (n NodeTypeExtensionCall) marshalCedar(buf *bytes.Buffer) {
 }
 
 func (n NodeTypeContains) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContains.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(".contains(")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContains.Right, buf)
+	marshalChildNode(n.precedenceLevel(), n.Right, buf)
 	buf.WriteRune(')')
 }
 
 func (n NodeTypeContainsAll) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContainsAll.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(".containsAll(")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContainsAll.Right, buf)
+	marshalChildNode(n.precedenceLevel(), n.Right, buf)
 	buf.WriteRune(')')
 }
 
 func (n NodeTypeContainsAny) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContainsAny.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(".containsAny(")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeContainsAny.Right, buf)
+	marshalChildNode(n.precedenceLevel(), n.Right, buf)
 	buf.WriteRune(')')
 }
 
 func (n NodeTypeIsEmpty) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIsEmpty.Arg, buf)
+	marshalChildNode(n.precedenceLevel(), n.Arg, buf)
 	buf.WriteString(".isEmpty()")
 }
 
 func (n NodeTypeGetTag) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeGetTag.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(".getTag(")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeGetTag.Right, buf)
+	marshalChildNode(n.precedenceLevel(), n.Right, buf)
 	buf.WriteRune(')')
 }
 
 func (n NodeTypeHasTag) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeHasTag.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(".hasTag(")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeHasTag.Right, buf)
+	marshalChildNode(n.precedenceLevel(), n.Right, buf)
 	buf.WriteRune(')')
 }
 
 func (n NodeTypeSet) marshalCedar(buf *bytes.Buffer) {
 	buf.WriteRune('[')
-	for i := range n.NodeTypeSet.Elements {
-		marshalChildNode(n.precedenceLevel(), n.NodeTypeSet.Elements[i], buf)
-		if i != len(n.NodeTypeSet.Elements)-1 {
+	for i := range n.Elements {
+		marshalChildNode(n.precedenceLevel(), n.Elements[i], buf)
+		if i != len(n.Elements)-1 {
 			buf.WriteString(", ")
 		}
 	}
@@ -235,11 +235,11 @@ func (n NodeTypeSet) marshalCedar(buf *bytes.Buffer) {
 
 func (n NodeTypeRecord) marshalCedar(buf *bytes.Buffer) {
 	buf.WriteRune('{')
-	for i := range n.NodeTypeRecord.Elements {
-		buf.Write(n.NodeTypeRecord.Elements[i].Key.MarshalCedar())
+	for i := range n.Elements {
+		buf.Write(n.Elements[i].Key.MarshalCedar())
 		buf.WriteString(":")
 		marshalChildNode(n.precedenceLevel(), n.NodeTypeRecord.Elements[i].Value, buf)
-		if i != len(n.NodeTypeRecord.Elements)-1 {
+		if i != len(n.Elements)-1 {
 			buf.WriteString(", ")
 		}
 	}
@@ -255,90 +255,90 @@ func marshalInfixBinaryOp(n ast.BinaryNode, precedence nodePrecedenceLevel, op s
 }
 
 func (n NodeTypeMult) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeMult.BinaryNode, n.precedenceLevel(), "*", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "*", buf)
 }
 
 func (n NodeTypeAdd) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeAdd.BinaryNode, n.precedenceLevel(), "+", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "+", buf)
 }
 
 func (n NodeTypeSub) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeSub.BinaryNode, n.precedenceLevel(), "-", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "-", buf)
 }
 
 func (n NodeTypeLessThan) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeLessThan.BinaryNode, n.precedenceLevel(), "<", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "<", buf)
 }
 
 func (n NodeTypeLessThanOrEqual) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeLessThanOrEqual.BinaryNode, n.precedenceLevel(), "<=", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "<=", buf)
 }
 
 func (n NodeTypeGreaterThan) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeGreaterThan.BinaryNode, n.precedenceLevel(), ">", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), ">", buf)
 }
 
 func (n NodeTypeGreaterThanOrEqual) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeGreaterThanOrEqual.BinaryNode, n.precedenceLevel(), ">=", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), ">=", buf)
 }
 
 func (n NodeTypeEquals) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeEquals.BinaryNode, n.precedenceLevel(), "==", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "==", buf)
 }
 
 func (n NodeTypeNotEquals) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeNotEquals.BinaryNode, n.precedenceLevel(), "!=", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "!=", buf)
 }
 
 func (n NodeTypeIn) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeIn.BinaryNode, n.precedenceLevel(), "in", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "in", buf)
 }
 
 func (n NodeTypeAnd) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeAnd.BinaryNode, n.precedenceLevel(), "&&", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "&&", buf)
 }
 
 func (n NodeTypeOr) marshalCedar(buf *bytes.Buffer) {
-	marshalInfixBinaryOp(n.NodeTypeOr.BinaryNode, n.precedenceLevel(), "||", buf)
+	marshalInfixBinaryOp(n.BinaryNode, n.precedenceLevel(), "||", buf)
 }
 
 func (n NodeTypeHas) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeHas.Arg, buf)
+	marshalChildNode(n.precedenceLevel(), n.Arg, buf)
 	buf.WriteString(" has ")
-	if canMarshalAsIdent(string(n.NodeTypeHas.Value)) {
-		buf.WriteString(string(n.NodeTypeHas.Value))
+	if canMarshalAsIdent(string(n.Value)) {
+		buf.WriteString(string(n.Value))
 	} else {
-		buf.Write(n.NodeTypeHas.Value.MarshalCedar())
+		buf.Write(n.Value.MarshalCedar())
 	}
 }
 
 func (n NodeTypeIs) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIs.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(" is ")
-	buf.WriteString(string(n.NodeTypeIs.EntityType))
+	buf.WriteString(string(n.EntityType))
 }
 
 func (n NodeTypeIsIn) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIsIn.Left, buf)
+	marshalChildNode(n.precedenceLevel(), n.Left, buf)
 	buf.WriteString(" is ")
-	buf.WriteString(string(n.NodeTypeIsIn.EntityType))
+	buf.WriteString(string(n.EntityType))
 	buf.WriteString(" in ")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIsIn.Entity, buf)
+	marshalChildNode(n.precedenceLevel(), n.Entity, buf)
 }
 
 func (n NodeTypeLike) marshalCedar(buf *bytes.Buffer) {
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeLike.Arg, buf)
+	marshalChildNode(n.precedenceLevel(), n.Arg, buf)
 	buf.WriteString(" like ")
-	buf.Write(n.NodeTypeLike.Value.MarshalCedar())
+	buf.Write(n.Value.MarshalCedar())
 }
 
 func (n NodeTypeIf) marshalCedar(buf *bytes.Buffer) {
 	buf.WriteString("if ")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIfThenElse.If, buf)
+	marshalChildNode(n.precedenceLevel(), n.If, buf)
 	buf.WriteString(" then ")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIfThenElse.Then, buf)
+	marshalChildNode(n.precedenceLevel(), n.Then, buf)
 	buf.WriteString(" else ")
-	marshalChildNode(n.precedenceLevel(), n.NodeTypeIfThenElse.Else, buf)
+	marshalChildNode(n.precedenceLevel(), n.Else, buf)
 }
 
 func astNodeToMarshalNode(astNode ast.IsNode) IsNode {

--- a/internal/parser/cedar_tokenize.go
+++ b/internal/parser/cedar_tokenize.go
@@ -287,13 +287,13 @@ func (s *scanner) scanInteger(ch rune) rune {
 	return ch
 }
 
-func (s *scanner) scanHexDigits(ch rune, min, max int) rune {
+func (s *scanner) scanHexDigits(ch rune, minDigits, maxDigits int) rune {
 	n := 0
-	for n < max && rust.IsHexadecimal(ch) {
+	for n < maxDigits && rust.IsHexadecimal(ch) {
 		ch = s.next()
 		n++
 	}
-	if n < min || n > max {
+	if n < minDigits || n > maxDigits {
 		s.error("invalid char escape")
 	}
 	return ch

--- a/policy.go
+++ b/policy.go
@@ -11,6 +11,20 @@ import (
 	internalast "github.com/cedar-policy/cedar-go/x/exp/ast"
 )
 
+//revive:disable:exported
+type Annotations = types.Annotations
+
+type Effect = types.Effect
+
+const (
+	Permit = types.Permit
+	Forbid = types.Forbid
+)
+
+type Position = types.Position
+
+//revive:enable:exported
+
 // A Policy is the parsed form of a single Cedar language policy statement.
 type Policy struct {
 	eval eval.BoolEvaler // determines if a policy matches a request.
@@ -73,8 +87,6 @@ func NewPolicyFromAST(astIn *ast.Policy) *Policy {
 	return p
 }
 
-type Annotations = types.Annotations
-
 // Annotations retrieves the annotations associated with this policy.
 func (p *Policy) Annotations() Annotations {
 	res := make(Annotations, len(p.ast.Annotations))
@@ -84,19 +96,10 @@ func (p *Policy) Annotations() Annotations {
 	return res
 }
 
-type Effect = types.Effect
-
-const (
-	Permit = types.Permit
-	Forbid = types.Forbid
-)
-
 // Effect retrieves the effect of this policy.
 func (p *Policy) Effect() Effect {
 	return Effect(p.ast.Effect)
 }
-
-type Position = types.Position
 
 // Position retrieves the position of this policy.
 func (p *Policy) Position() Position {

--- a/policy_set.go
+++ b/policy_set.go
@@ -13,6 +13,7 @@ import (
 	internalast "github.com/cedar-policy/cedar-go/x/exp/ast"
 )
 
+//revive:disable-next-line:exported
 type PolicyID = types.PolicyID
 
 // PolicyMap is a map of policy IDs to policy

--- a/policy_test.go
+++ b/policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cedar-policy/cedar-go/internal/testutil"
 )
 
-func prettifyJson(in []byte) []byte {
+func prettifyJSON(in []byte) []byte {
 	var buf bytes.Buffer
 	_ = json.Indent(&buf, in, "", "    ")
 	return buf.Bytes()
@@ -20,7 +20,7 @@ func TestPolicyJSON(t *testing.T) {
 	t.Parallel()
 
 	// Taken from https://docs.cedarpolicy.com/policies/json-format.html
-	jsonEncodedPolicy := prettifyJson([]byte(`
+	jsonEncodedPolicy := prettifyJSON([]byte(`
 		{
 			"effect": "permit",
 			"principal": {
@@ -64,7 +64,7 @@ func TestPolicyJSON(t *testing.T) {
 	output, err := policy.MarshalJSON()
 	testutil.OK(t, err)
 
-	testutil.Equals(t, string(prettifyJson(output)), string(jsonEncodedPolicy))
+	testutil.Equals(t, string(prettifyJSON(output)), string(jsonEncodedPolicy))
 }
 
 func TestPolicyCedar(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+//revive:disable:exported
+
 //  _____
 // |_   _|   _ _ __   ___  ___
 //   | || | | | '_ \ / _ \/ __|
@@ -53,6 +55,8 @@ const (
 	True  = types.True
 	False = types.False
 )
+
+//revive:enable:exported
 
 //   ____                _                   _
 //  / ___|___  _ __  ___| |_ _ __ _   _  ___| |_ ___  _ __ ___

--- a/types/boolean.go
+++ b/types/boolean.go
@@ -8,24 +8,24 @@ const (
 	False = Boolean(false)
 )
 
-func (a Boolean) Equal(bi Value) bool {
-	b, ok := bi.(Boolean)
-	return ok && a == b
+func (b Boolean) Equal(bi Value) bool {
+	bo, ok := bi.(Boolean)
+	return ok && b == bo
 }
 
 // String produces a string representation of the Boolean, e.g. `true`.
-func (v Boolean) String() string { return string(v.MarshalCedar()) }
+func (b Boolean) String() string { return string(b.MarshalCedar()) }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the Boolean, e.g. `true`.
-func (v Boolean) MarshalCedar() []byte {
-	if v {
+func (b Boolean) MarshalCedar() []byte {
+	if b {
 		return []byte("true")
 	}
 	return []byte("false")
 }
 
-func (v Boolean) hash() uint64 {
-	if v {
+func (b Boolean) hash() uint64 {
+	if b {
 		return 1
 	}
 	return 0

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -56,10 +56,7 @@ func ParseDatetime(s string) (Datetime, error) {
 	// DD is at offset 8
 	// - is at 4 and 7
 	// YYYY
-	if !(unicode.IsDigit(rune(s[0])) &&
-		unicode.IsDigit(rune(s[1])) &&
-		unicode.IsDigit(rune(s[2])) &&
-		unicode.IsDigit(rune(s[3]))) {
+	if !unicode.IsDigit(rune(s[0])) || !unicode.IsDigit(rune(s[1])) || !unicode.IsDigit(rune(s[2])) || !unicode.IsDigit(rune(s[3])) {
 		return Datetime{}, fmt.Errorf("%w: invalid year", errDatetime)
 	}
 	year = 1000*int(rune(s[0])-'0') +
@@ -72,8 +69,7 @@ func ParseDatetime(s string) (Datetime, error) {
 	}
 
 	// MM
-	if !(unicode.IsDigit(rune(s[5])) &&
-		unicode.IsDigit(rune(s[6]))) {
+	if !unicode.IsDigit(rune(s[5])) || !unicode.IsDigit(rune(s[6])) {
 		return Datetime{}, fmt.Errorf("%w: invalid month", errDatetime)
 	}
 	month = 10*int(rune(s[5])-'0') + int(rune(s[6])-'0')
@@ -86,8 +82,7 @@ func ParseDatetime(s string) (Datetime, error) {
 	}
 
 	// DD
-	if !(unicode.IsDigit(rune(s[8])) &&
-		unicode.IsDigit(rune(s[9]))) {
+	if !unicode.IsDigit(rune(s[8])) || !unicode.IsDigit(rune(s[9])) {
 		return Datetime{}, fmt.Errorf("%w: invalid day", errDatetime)
 	}
 	day = 10*int(rune(s[8])-'0') + int(rune(s[9])-'0')
@@ -118,8 +113,7 @@ func ParseDatetime(s string) (Datetime, error) {
 		return Datetime{}, fmt.Errorf("%w: unexpected character %s", errDatetime, strconv.QuoteRune(rune(s[10])))
 	}
 
-	if !(unicode.IsDigit(rune(s[11])) &&
-		unicode.IsDigit(rune(s[12]))) {
+	if !unicode.IsDigit(rune(s[11])) || !unicode.IsDigit(rune(s[12])) {
 		return Datetime{}, fmt.Errorf("%w: invalid hour", errDatetime)
 	}
 	hour = 10*int(rune(s[11])-'0') + int(rune(s[12])-'0')
@@ -131,8 +125,7 @@ func ParseDatetime(s string) (Datetime, error) {
 		return Datetime{}, fmt.Errorf("%w: unexpected character %s", errDatetime, strconv.QuoteRune(rune(s[13])))
 	}
 
-	if !(unicode.IsDigit(rune(s[14])) &&
-		unicode.IsDigit(rune(s[15]))) {
+	if !unicode.IsDigit(rune(s[14])) || !unicode.IsDigit(rune(s[15])) {
 		return Datetime{}, fmt.Errorf("%w: invalid minute", errDatetime)
 	}
 	minute = 10*int(rune(s[14])-'0') + int(rune(s[15])-'0')
@@ -144,8 +137,7 @@ func ParseDatetime(s string) (Datetime, error) {
 		return Datetime{}, fmt.Errorf("%w: unexpected character %s", errDatetime, strconv.QuoteRune(rune(s[16])))
 	}
 
-	if !(unicode.IsDigit(rune(s[17])) &&
-		unicode.IsDigit(rune(s[18]))) {
+	if !unicode.IsDigit(rune(s[17])) || !unicode.IsDigit(rune(s[18])) {
 		return Datetime{}, fmt.Errorf("%w: invalid second", errDatetime)
 	}
 	second = 10*int(rune(s[17])-'0') + int(rune(s[18])-'0')
@@ -163,9 +155,7 @@ func ParseDatetime(s string) (Datetime, error) {
 			return Datetime{}, fmt.Errorf("%w: invalid millisecond", errDatetime)
 		}
 
-		if !(unicode.IsDigit(rune(s[20])) &&
-			unicode.IsDigit(rune(s[21])) &&
-			unicode.IsDigit(rune(s[22]))) {
+		if !unicode.IsDigit(rune(s[20])) || !unicode.IsDigit(rune(s[21])) || !unicode.IsDigit(rune(s[22])) {
 			return Datetime{}, fmt.Errorf("%w: invalid millisecond", errDatetime)
 		}
 
@@ -197,10 +187,7 @@ func ParseDatetime(s string) (Datetime, error) {
 		}
 
 		// get the time zone offset hhmm.
-		if !(unicode.IsDigit(rune(s[trailerOffset+1])) &&
-			unicode.IsDigit(rune(s[trailerOffset+2])) &&
-			unicode.IsDigit(rune(s[trailerOffset+3])) &&
-			unicode.IsDigit(rune(s[trailerOffset+4]))) {
+		if !unicode.IsDigit(rune(s[trailerOffset+1])) || !unicode.IsDigit(rune(s[trailerOffset+2])) || !unicode.IsDigit(rune(s[trailerOffset+3])) || !unicode.IsDigit(rune(s[trailerOffset+4])) {
 			return Datetime{}, fmt.Errorf("%w: invalid time zone offset", errDatetime)
 		}
 
@@ -236,42 +223,42 @@ func ParseDatetime(s string) (Datetime, error) {
 }
 
 // Equal returns true if the input represents the same timestamp.
-func (a Datetime) Equal(bi Value) bool {
+func (d Datetime) Equal(bi Value) bool {
 	b, ok := bi.(Datetime)
-	return ok && a == b
+	return ok && d == b
 }
 
 // LessThan returns true if value is less than the argument and they
 // are both Datetime values, or an error indicating they aren't
 // comparable otherwise
-func (a Datetime) LessThan(bi Value) (bool, error) {
+func (d Datetime) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Datetime)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a.value < b.value, nil
+	return d.value < b.value, nil
 }
 
 // LessThan returns true if value is less than or equal to the
 // argument and they are both Datetime values, or an error indicating
 // they aren't comparable otherwise
-func (a Datetime) LessThanOrEqual(bi Value) (bool, error) {
+func (d Datetime) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Datetime)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a.value <= b.value, nil
+	return d.value <= b.value, nil
 }
 
 // MarshalCedar returns a []byte which, when parsed by the Cedar
 // Parser, returns an Equal Datetime value
-func (a Datetime) MarshalCedar() []byte {
-	return []byte(`datetime("` + a.String() + `")`)
+func (d Datetime) MarshalCedar() []byte {
+	return []byte(`datetime("` + d.String() + `")`)
 }
 
 // String returns an ISO 8601 millisecond precision timestamp
-func (a Datetime) String() string {
-	return time.UnixMilli(a.value).UTC().Format("2006-01-02T15:04:05.000Z")
+func (d Datetime) String() string {
+	return time.UnixMilli(d.value).UTC().Format("2006-01-02T15:04:05.000Z")
 }
 
 // UnmarshalJSON implements encoding/json.Unmarshaler for Datetime
@@ -280,36 +267,36 @@ func (a Datetime) String() string {
 //   - { "__extn": { "fn": "datetime", "arg": "1970-01-01" }}
 //   - { "fn": "datetime", "arg": "1970-01-01" }
 //   - "1970-01-01"
-func (a *Datetime) UnmarshalJSON(b []byte) error {
+func (d *Datetime) UnmarshalJSON(b []byte) error {
 	aa, err := unmarshalExtensionValue(b, "datetime", ParseDatetime)
 	if err != nil {
 		return err
 	}
 
-	*a = aa
+	*d = aa
 	return nil
 }
 
 // MarshalJSON marshals a Cedar Datetime with the explicit representation
-func (a Datetime) MarshalJSON() ([]byte, error) {
+func (d Datetime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "datetime",
-			Arg: a.String(),
+			Arg: d.String(),
 		},
 	})
 }
 
 // Milliseconds returns the number of milliseconds since the Unix epoch
-func (a Datetime) Milliseconds() int64 {
-	return a.value
+func (d Datetime) Milliseconds() int64 {
+	return d.value
 }
 
 // Time returns the UTC time.Time representation of a Datetime.
-func (a Datetime) Time() time.Time {
-	return time.UnixMilli(a.value).UTC()
+func (d Datetime) Time() time.Time {
+	return time.UnixMilli(d.value).UTC()
 }
 
-func (v Datetime) hash() uint64 {
-	return uint64(v.value)
+func (d Datetime) hash() uint64 {
+	return uint64(d.value)
 }

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -123,10 +123,10 @@ func TestDecimal(t *testing.T) {
 		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
 		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
 
-		max := testutil.Must(types.NewDecimal(9223372036854775807, -4))
-		testutil.Equals(t, max, testutil.Must(types.ParseDecimal("922337203685477.5807")))
-		min := testutil.Must(types.NewDecimal(-9223372036854775808, -4))
-		testutil.Equals(t, min, testutil.Must(types.ParseDecimal("-922337203685477.5808")))
+		maxVal := testutil.Must(types.NewDecimal(9223372036854775807, -4))
+		testutil.Equals(t, maxVal, testutil.Must(types.ParseDecimal("922337203685477.5807")))
+		minVal := testutil.Must(types.NewDecimal(-9223372036854775808, -4))
+		testutil.Equals(t, minVal, testutil.Must(types.ParseDecimal("-922337203685477.5808")))
 	})
 
 	t.Run("Compare", func(t *testing.T) {

--- a/types/duration.go
+++ b/types/duration.go
@@ -132,46 +132,46 @@ func ParseDuration(s string) (Duration, error) {
 }
 
 // Equal returns true if the input represents the same duration
-func (a Duration) Equal(bi Value) bool {
+func (d Duration) Equal(bi Value) bool {
 	b, ok := bi.(Duration)
-	return ok && a == b
+	return ok && d == b
 }
 
 // LessThan returns true if value is less than the argument and they
 // are both Duration values, or an error indicating they aren't
 // comparable otherwise
-func (a Duration) LessThan(bi Value) (bool, error) {
+func (d Duration) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Duration)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a.value < b.value, nil
+	return d.value < b.value, nil
 }
 
 // LessThan returns true if value is less than or equal to the
 // argument and they are both Duration values, or an error indicating
 // they aren't comparable otherwise
-func (a Duration) LessThanOrEqual(bi Value) (bool, error) {
+func (d Duration) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Duration)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a.value <= b.value, nil
+	return d.value <= b.value, nil
 }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the Duration, e.g. `decimal("12.34")`.
-func (v Duration) MarshalCedar() []byte { return []byte(`duration("` + v.String() + `")`) }
+func (d Duration) MarshalCedar() []byte { return []byte(`duration("` + d.String() + `")`) }
 
 // String produces a string representation of the Duration
-func (v Duration) String() string {
+func (d Duration) String() string {
 	var res bytes.Buffer
-	if v.value == 0 {
+	if d.value == 0 {
 		return "0ms"
 	}
 
-	remaining := v.value
-	if v.value < 0 {
-		remaining = -v.value
+	remaining := d.value
+	if d.value < 0 {
+		remaining = -d.value
 		res.WriteByte('-')
 	}
 
@@ -217,68 +217,68 @@ func (v Duration) String() string {
 //   - { "__extn": { "fn": "duration", "arg": "1h10m" }}
 //   - { "fn": "duration", "arg": "1h10m" }
 //   - "1h10m"
-func (v *Duration) UnmarshalJSON(b []byte) error {
+func (d *Duration) UnmarshalJSON(b []byte) error {
 	vv, err := unmarshalExtensionValue(b, "duration", ParseDuration)
 	if err != nil {
 		return err
 	}
 
-	*v = vv
+	*d = vv
 	return nil
 }
 
 // MarshalJSON marshals the Duration into JSON using the explicit form.
-func (v Duration) MarshalJSON() ([]byte, error) {
+func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "duration",
-			Arg: v.String(),
+			Arg: d.String(),
 		},
 	})
 }
 
 // ToDays returns the number of days this Duration represents,
 // truncating when fractional
-func (v Duration) ToDays() int64 {
-	return v.value / consts.MillisPerDay
+func (d Duration) ToDays() int64 {
+	return d.value / consts.MillisPerDay
 }
 
 // ToHours returns the number of hours this Duration represents,
 // truncating when fractional
-func (v Duration) ToHours() int64 {
-	return v.value / consts.MillisPerHour
+func (d Duration) ToHours() int64 {
+	return d.value / consts.MillisPerHour
 }
 
 // ToMinutes returns the number of minutes this Duration represents,
 // truncating when fractional
-func (v Duration) ToMinutes() int64 {
-	return v.value / consts.MillisPerMinute
+func (d Duration) ToMinutes() int64 {
+	return d.value / consts.MillisPerMinute
 }
 
 // ToSeconds returns the number of seconds this Duration represents,
 // truncating when fractional
-func (v Duration) ToSeconds() int64 {
-	return v.value / consts.MillisPerSecond
+func (d Duration) ToSeconds() int64 {
+	return d.value / consts.MillisPerSecond
 }
 
 // ToMilliseconds returns the number of milliseconds this Duration
 // represents
-func (v Duration) ToMilliseconds() int64 {
-	return v.value
+func (d Duration) ToMilliseconds() int64 {
+	return d.value
 }
 
 // Duration returns a time.Duration representation of a Duration.  An error
 // is returned if the duration cannot be converted to a time.Duration.
-func (v Duration) Duration() (time.Duration, error) {
-	if v.value > math.MaxInt64/1000 {
+func (d Duration) Duration() (time.Duration, error) {
+	if d.value > math.MaxInt64/1000 {
 		return 0, internal.ErrDurationRange
 	}
-	if v.value < math.MinInt64/1000 {
+	if d.value < math.MinInt64/1000 {
 		return 0, internal.ErrDurationRange
 	}
-	return time.Millisecond * time.Duration(v.value), nil
+	return time.Millisecond * time.Duration(d.value), nil
 }
 
-func (v Duration) hash() uint64 {
-	return uint64(v.value)
+func (d Duration) hash() uint64 {
+	return uint64(d.value)
 }

--- a/types/entity_uid.go
+++ b/types/entity_uid.go
@@ -29,55 +29,55 @@ func NewEntityUID(typ EntityType, id String) EntityUID {
 }
 
 // IsZero returns true if the EntityUID has an empty Type and ID.
-func (a EntityUID) IsZero() bool {
-	return a.Type == "" && a.ID == ""
+func (e EntityUID) IsZero() bool {
+	return e.Type == "" && e.ID == ""
 }
 
-func (a EntityUID) Equal(bi Value) bool {
+func (e EntityUID) Equal(bi Value) bool {
 	b, ok := bi.(EntityUID)
-	return ok && a == b
+	return ok && e == b
 }
 
 // String produces a string representation of the EntityUID, e.g. `Type::"id"`.
-func (v EntityUID) String() string { return string(v.Type) + "::" + strconv.Quote(string(v.ID)) }
+func (e EntityUID) String() string { return string(e.Type) + "::" + strconv.Quote(string(e.ID)) }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the EntityUID, e.g. `Type::"id"`.
-func (v EntityUID) MarshalCedar() []byte {
-	return []byte(v.String())
+func (e EntityUID) MarshalCedar() []byte {
+	return []byte(e.String())
 }
 
-func (v *EntityUID) UnmarshalJSON(b []byte) error {
+func (e *EntityUID) UnmarshalJSON(b []byte) error {
 	// TODO: review after adding support for schemas
 	var res entityValueJSON
 	if err := json.Unmarshal(b, &res); err != nil {
 		return err
 	}
 	if res.Entity != nil {
-		v.Type = EntityType(res.Entity.Type)
-		v.ID = String(res.Entity.ID)
+		e.Type = EntityType(res.Entity.Type)
+		e.ID = String(res.Entity.ID)
 		return nil
 	} else if res.Type != nil && res.ID != nil { // require both Type and ID to parse "implicit" JSON
-		v.Type = EntityType(*res.Type)
-		v.ID = String(*res.ID)
+		e.Type = EntityType(*res.Type)
+		e.ID = String(*res.ID)
 		return nil
 	}
 	return errJSONEntityNotFound
 }
 
 // MarshalJSON marshals the EntityUID into JSON using the explicit form.
-func (v EntityUID) MarshalJSON() ([]byte, error) {
+func (e EntityUID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityValueJSON{
 		Entity: &extEntity{
-			Type: string(v.Type),
-			ID:   string(v.ID),
+			Type: string(e.Type),
+			ID:   string(e.ID),
 		},
 	})
 }
 
-func (v EntityUID) hash() uint64 {
+func (e EntityUID) hash() uint64 {
 	h := fnv.New64()
-	_, _ = h.Write([]byte(v.Type))
-	_, _ = h.Write([]byte(v.ID))
+	_, _ = h.Write([]byte(e.Type))
+	_, _ = h.Write([]byte(e.ID))
 	return h.Sum64()
 }
 

--- a/types/ipaddr.go
+++ b/types/ipaddr.go
@@ -25,40 +25,40 @@ func ParseIPAddr(s string) (IPAddr, error) {
 		return IPAddr(net), nil
 	} else if addr, err := netip.ParseAddr(s); err == nil {
 		return IPAddr(netip.PrefixFrom(addr, addr.BitLen())), nil
-	} else {
-		return IPAddr{}, fmt.Errorf("%w: error parsing IP address %s", errIP, s)
 	}
+	return IPAddr{}, fmt.Errorf("%w: error parsing IP address %s", errIP, s)
 }
 
-func (a IPAddr) Equal(bi Value) bool {
+// Equal returns true if the argument is equal to a
+func (i IPAddr) Equal(bi Value) bool {
 	b, ok := bi.(IPAddr)
-	return ok && a == b
+	return ok && i == b
 }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the IPAddr, e.g. `ip("127.0.0.1")`.
-func (v IPAddr) MarshalCedar() []byte { return []byte(`ip("` + v.String() + `")`) }
+func (i IPAddr) MarshalCedar() []byte { return []byte(`ip("` + i.String() + `")`) }
 
 // String produces a string representation of the IPAddr, e.g. `127.0.0.1`.
-func (v IPAddr) String() string {
-	if v.Prefix().Bits() == v.Addr().BitLen() {
-		return v.Addr().String()
+func (i IPAddr) String() string {
+	if i.Prefix().Bits() == i.Addr().BitLen() {
+		return i.Addr().String()
 	}
-	return v.Prefix().String()
+	return i.Prefix().String()
 }
 
-func (v IPAddr) Prefix() netip.Prefix {
-	return netip.Prefix(v)
+func (i IPAddr) Prefix() netip.Prefix {
+	return netip.Prefix(i)
 }
 
-func (v IPAddr) IsIPv4() bool {
-	return v.Addr().Is4()
+func (i IPAddr) IsIPv4() bool {
+	return i.Addr().Is4()
 }
 
-func (v IPAddr) IsIPv6() bool {
-	return v.Addr().Is6()
+func (i IPAddr) IsIPv6() bool {
+	return i.Addr().Is6()
 }
 
-func (v IPAddr) IsLoopback() bool {
+func (i IPAddr) IsLoopback() bool {
 	// This comment is in the Cedar Rust implementation:
 	//
 	// 		Loopback addresses are "127.0.0.0/8" for IpV4 and "::1" for IpV6
@@ -70,14 +70,14 @@ func (v IPAddr) IsLoopback() bool {
 	// 		The reason for IpV4 is that provided the truncated ip address is a
 	// 		loopback address, its prefix cannot be less than 8 because
 	// 		otherwise its more significant byte cannot be 127
-	return v.Prefix().Masked().Addr().IsLoopback()
+	return i.Prefix().Masked().Addr().IsLoopback()
 }
 
-func (v IPAddr) Addr() netip.Addr {
-	return netip.Prefix(v).Addr()
+func (i IPAddr) Addr() netip.Addr {
+	return netip.Prefix(i).Addr()
 }
 
-func (v IPAddr) IsMulticast() bool {
+func (i IPAddr) IsMulticast() bool {
 	// This comment is in the Cedar Rust implementation:
 	//
 	// 		Multicast addresses are "224.0.0.0/4" for IpV4 and "ff00::/8" for
@@ -90,17 +90,17 @@ func (v IPAddr) IsMulticast() bool {
 	// 		The implementation uses the property that if `ip1/prefix1` is in
 	// 		range `ip2/prefix2`, then `ip1` is in `ip2/prefix2` and `prefix1 >=
 	// 		prefix2`
-	var min_prefix_len int
-	if v.IsIPv4() {
-		min_prefix_len = 4
+	var minPrefixLen int
+	if i.IsIPv4() {
+		minPrefixLen = 4
 	} else {
-		min_prefix_len = 8
+		minPrefixLen = 8
 	}
-	return v.Addr().IsMulticast() && v.Prefix().Bits() >= min_prefix_len
+	return i.Addr().IsMulticast() && i.Prefix().Bits() >= minPrefixLen
 }
 
-func (c IPAddr) Contains(o IPAddr) bool {
-	return c.Prefix().Contains(o.Addr()) && c.Prefix().Bits() <= o.Prefix().Bits()
+func (i IPAddr) Contains(o IPAddr) bool {
+	return i.Prefix().Contains(o.Addr()) && i.Prefix().Bits() <= o.Prefix().Bits()
 }
 
 // UnmarshalJSON implements encoding/json.Unmarshaler for IPAddr
@@ -109,37 +109,37 @@ func (c IPAddr) Contains(o IPAddr) bool {
 //   - { "__extn": { "fn": "ip", "arg": "12.34.56.78" }}
 //   - { "fn": "ip", "arg": "12.34.56.78" }
 //   - "12.34.56.78"
-func (v *IPAddr) UnmarshalJSON(b []byte) error {
+func (i *IPAddr) UnmarshalJSON(b []byte) error {
 	vv, err := unmarshalExtensionValue(b, "ip", ParseIPAddr)
 	if err != nil {
 		return err
 	}
 
-	*v = vv
+	*i = vv
 	return nil
 }
 
 // MarshalJSON marshals the IPAddr into JSON using the explicit form.
-func (v IPAddr) MarshalJSON() ([]byte, error) {
-	if v.Prefix().Bits() == v.Prefix().Addr().BitLen() {
+func (i IPAddr) MarshalJSON() ([]byte, error) {
+	if i.Prefix().Bits() == i.Prefix().Addr().BitLen() {
 		return json.Marshal(extValueJSON{
 			Extn: &extn{
 				Fn:  "ip",
-				Arg: v.Addr().String(),
+				Arg: i.Addr().String(),
 			},
 		})
 	}
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "ip",
-			Arg: v.String(),
+			Arg: i.String(),
 		},
 	})
 }
 
-func (v IPAddr) hash() uint64 {
+func (i IPAddr) hash() uint64 {
 	// MarshalBinary() cannot actually fail
-	bytes, _ := netip.Prefix(v).MarshalBinary()
+	bytes, _ := netip.Prefix(i).MarshalBinary()
 	h := fnv.New64()
 	_, _ = h.Write(bytes)
 	return h.Sum64()

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -16,8 +16,7 @@ func AssertValue(t *testing.T, got, want Value) {
 	t.Helper()
 	testutil.FatalIf(
 		t,
-		!((got == zeroValue() && want == zeroValue()) ||
-			(got != zeroValue() && want != zeroValue() && got.Equal(want))),
+		(got != zeroValue() || want != zeroValue()) && (got == zeroValue() || want == zeroValue() || !got.Equal(want)),
 		"got %v want %v", got, want)
 }
 

--- a/types/long.go
+++ b/types/long.go
@@ -9,35 +9,35 @@ import (
 // A Long is a whole number without decimals that can range from -9223372036854775808 to 9223372036854775807.
 type Long int64
 
-func (a Long) Equal(bi Value) bool {
+func (l Long) Equal(bi Value) bool {
 	b, ok := bi.(Long)
-	return ok && a == b
+	return ok && l == b
 }
 
-func (a Long) LessThan(bi Value) (bool, error) {
+func (l Long) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Long)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a < b, nil
+	return l < b, nil
 }
 
-func (a Long) LessThanOrEqual(bi Value) (bool, error) {
+func (l Long) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Long)
 	if !ok {
 		return false, internal.ErrNotComparable
 	}
-	return a <= b, nil
+	return l <= b, nil
 }
 
 // String produces a string representation of the Long, e.g. `42`.
-func (v Long) String() string { return fmt.Sprint(int64(v)) }
+func (l Long) String() string { return fmt.Sprint(int64(l)) }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the Long, e.g. `42`.
-func (v Long) MarshalCedar() []byte {
-	return []byte(v.String())
+func (l Long) MarshalCedar() []byte {
+	return []byte(l.String())
 }
 
-func (v Long) hash() uint64 {
-	return uint64(v)
+func (l Long) hash() uint64 {
+	return uint64(l)
 }

--- a/types/pattern.go
+++ b/types/pattern.go
@@ -62,7 +62,7 @@ func (p Pattern) MarshalCedar() []byte {
 		// TODO: This is wrong. It needs to escape unicode the Rustic way.
 		quotedString := strconv.Quote(comp.Literal)
 		quotedString = quotedString[1 : len(quotedString)-1]
-		quotedString = strings.Replace(quotedString, "*", "\\*", -1)
+		quotedString = strings.ReplaceAll(quotedString, "*", "\\*")
 		buf.WriteString(quotedString)
 	}
 	buf.WriteRune('"')

--- a/types/record.go
+++ b/types/record.go
@@ -77,12 +77,12 @@ func (r Record) Map() RecordMap {
 }
 
 // Equals returns true if the records are Equal.
-func (a Record) Equal(bi Value) bool {
+func (r Record) Equal(bi Value) bool {
 	b, ok := bi.(Record)
-	if !ok || len(a.m) != len(b.m) || a.hashVal != b.hashVal {
+	if !ok || len(r.m) != len(b.m) || r.hashVal != b.hashVal {
 		return false
 	}
-	for k, av := range a.m {
+	for k, av := range r.m {
 		bv, ok := b.m[k]
 		if !ok || !av.Equal(bv) {
 			return false
@@ -91,7 +91,7 @@ func (a Record) Equal(bi Value) bool {
 	return true
 }
 
-func (v *Record) UnmarshalJSON(b []byte) error {
+func (r *Record) UnmarshalJSON(b []byte) error {
 	var res map[string]explicitValue
 	err := json.Unmarshal(b, &res)
 	if err != nil {
@@ -101,16 +101,16 @@ func (v *Record) UnmarshalJSON(b []byte) error {
 	for kk, vv := range res {
 		m[String(kk)] = vv.Value
 	}
-	*v = NewRecord(m)
+	*r = NewRecord(m)
 	return nil
 }
 
 // MarshalJSON marshals the Record into JSON, the marshaller uses the explicit
 // JSON form for all the values in the Record.
-func (v Record) MarshalJSON() ([]byte, error) {
+func (r Record) MarshalJSON() ([]byte, error) {
 	w := &bytes.Buffer{}
 	w.WriteByte('{')
-	keys := maps.Keys(v.m)
+	keys := maps.Keys(r.m)
 	slices.Sort(keys)
 	for i, kk := range keys {
 		if i > 0 {
@@ -119,7 +119,7 @@ func (v Record) MarshalJSON() ([]byte, error) {
 		kb, _ := json.Marshal(kk) // json.Marshal cannot error on strings
 		w.Write(kb)
 		w.WriteByte(':')
-		vv := v.m[kk]
+		vv := r.m[kk]
 		vb, err := json.Marshal(vv)
 		if err != nil {
 			return nil, err
@@ -154,6 +154,6 @@ func (r Record) MarshalCedar() []byte {
 	return sb.Bytes()
 }
 
-func (v Record) hash() uint64 {
-	return v.hashVal
+func (r Record) hash() uint64 {
+	return r.hashVal
 }

--- a/types/set.go
+++ b/types/set.go
@@ -90,17 +90,17 @@ func (s Set) Slice() []Value {
 }
 
 // Equal returns true if the sets are Equal.
-func (as Set) Equal(bi Value) bool {
+func (s Set) Equal(bi Value) bool {
 	bs, ok := bi.(Set)
 	if !ok {
 		return false
 	}
 
-	if len(as.s) != len(bs.s) || as.hashVal != bs.hashVal {
+	if len(s.s) != len(bs.s) || s.hashVal != bs.hashVal {
 		return false
 	}
 
-	for _, v := range as.s {
+	for _, v := range s.s {
 		if !bs.Contains(v) {
 			return false
 		}
@@ -113,7 +113,7 @@ func (v *explicitValue) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON parses a JSON-encoded Cedar set literal into a Set
-func (v *Set) UnmarshalJSON(b []byte) error {
+func (s *Set) UnmarshalJSON(b []byte) error {
 	var res []explicitValue
 	err := json.Unmarshal(b, &res)
 	if err != nil {
@@ -125,22 +125,22 @@ func (v *Set) UnmarshalJSON(b []byte) error {
 		vals[i] = vv.Value
 	}
 
-	*v = NewSet(vals...)
+	*s = NewSet(vals...)
 	return nil
 }
 
 // MarshalJSON marshals the Set into JSON.
 // Set elements are rendered in hash order, which may differ from the original order.
-func (v Set) MarshalJSON() ([]byte, error) {
+func (s Set) MarshalJSON() ([]byte, error) {
 	w := &bytes.Buffer{}
 	w.WriteByte('[')
-	orderedKeys := maps.Keys(v.s)
+	orderedKeys := maps.Keys(s.s)
 	slices.Sort(orderedKeys)
 	for i, k := range orderedKeys {
 		if i != 0 {
 			w.WriteByte(',')
 		}
-		b, err := json.Marshal(v.s[k])
+		b, err := json.Marshal(s.s[k])
 		if err != nil {
 			return nil, err
 		}
@@ -151,25 +151,25 @@ func (v Set) MarshalJSON() ([]byte, error) {
 }
 
 // String produces a string representation of the Set, e.g. `[1,2,3]`.
-func (v Set) String() string { return string(v.MarshalCedar()) }
+func (s Set) String() string { return string(s.MarshalCedar()) }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the Set, e.g. `[1,2,3]`.
 // Set elements are rendered in hash order, which may differ from the original order.
-func (v Set) MarshalCedar() []byte {
+func (s Set) MarshalCedar() []byte {
 	var sb bytes.Buffer
 	sb.WriteRune('[')
-	orderedKeys := maps.Keys(v.s)
+	orderedKeys := maps.Keys(s.s)
 	slices.Sort(orderedKeys)
 	for i, k := range orderedKeys {
 		if i != 0 {
 			sb.WriteString(", ")
 		}
-		sb.Write(v.s[k].MarshalCedar())
+		sb.Write(s.s[k].MarshalCedar())
 	}
 	sb.WriteRune(']')
 	return sb.Bytes()
 }
 
-func (v Set) hash() uint64 {
-	return v.hashVal
+func (s Set) hash() uint64 {
+	return s.hashVal
 }

--- a/types/string.go
+++ b/types/string.go
@@ -8,23 +8,24 @@ import (
 // A String is a sequence of characters consisting of letters, numbers, or symbols.
 type String string
 
-func (a String) Equal(bi Value) bool {
+// Equal returns true if two Strings are equal
+func (s String) Equal(bi Value) bool {
 	b, ok := bi.(String)
-	return ok && a == b
+	return ok && s == b
 }
 
 // String produces an unquoted string representation of the String, e.g. `hello`.
-func (v String) String() string {
-	return string(v)
+func (s String) String() string {
+	return string(s)
 }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the String, e.g. `"hello"`.
-func (v String) MarshalCedar() []byte {
-	return []byte(strconv.Quote(string(v)))
+func (s String) MarshalCedar() []byte {
+	return []byte(strconv.Quote(string(s)))
 }
 
-func (v String) hash() uint64 {
+func (s String) hash() uint64 {
 	h := fnv.New64()
-	_, _ = h.Write([]byte(v))
+	_, _ = h.Write([]byte(s))
 	return h.Sum64()
 }

--- a/x/exp/ast/doc.go
+++ b/x/exp/ast/doc.go
@@ -1,5 +1,5 @@
 /*
-The AST package exposes the internal AST used within cedar-go.  This AST is
+Package ast exposes the internal AST used within cedar-go.  This AST is
 subject to change.  The AST is most useful for analyzing existing policies
 created by the Cedar / JSON parser or created using the external AST.  The
 external AST is a type definition of the internal AST, so you can cast from the


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I ran `golangci-lint run ./... --fix` and it made all of these changes. At a cursory glance, they all seem to make sense.

I changed the config to enable the same set of linters but turned on almost all the `revive` rules. I disabled `exported` for the `internal` and `x` directories, which seems legit to me, but also had to disable it for the `types` directory for now until we can get our documentation up to snuff.