### PR TITLE
minor: use `cedar.Authorize`  in ReadMe.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func main() {
         }),
 	}
 
-	ok, _ := ps.IsAuthorized(entities, req)
+	ok, _ := cedar.Authorize(ps, entities, req)
 	fmt.Println(ok)
 }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use `cedar.Authorize` instead of PolicySet's `IsAuthorized` method in ReadMe.md example 


