### PR TITLE
types: add Entity.Equal() implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ If you're looking to integrate Cedar into a production system, please be sure th
 
 ## Change log
 
+### 1.2.3
+#### New Features
+- Adds Entity.Equal()
+
+### 1.2.2
+#### New Features
+- Adds experimental support for inspecting Cedar policy AST
+
 ### 1.2.1
 #### New Features
 - Fixes the name of `AuthorizationPolicySet` and receiver types for `PolicySet.Get()` and `PolicySet.IsAuthorized()`

--- a/types/entity.go
+++ b/types/entity.go
@@ -42,3 +42,10 @@ func (e Entity) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(m)
 }
+
+func (e Entity) Equal(other Entity) bool {
+	return e.UID.Equal(other.UID) &&
+		e.Parents.Equal(other.Parents) &&
+		e.Attributes.Equal(other.Attributes) &&
+		e.Tags.Equal(other.Tags)
+}

--- a/types/entity_test.go
+++ b/types/entity_test.go
@@ -94,3 +94,102 @@ func TestEntityTagMarshalJSON(t *testing.T) {
             }
 		}`)
 }
+
+func TestEntityEqual(t *testing.T) {
+	t.Parallel()
+
+	baseEntity := types.Entity{
+		UID: types.NewEntityUID("FooType", "1"),
+		Parents: types.NewEntityUIDSet(
+			types.NewEntityUID("BarType", "1"),
+			types.NewEntityUID("BazType", "2"),
+		),
+		Attributes: types.NewRecord(types.RecordMap{
+			"attr1": types.String("value1"),
+			"attr2": types.Long(42),
+		}),
+		Tags: types.NewRecord(types.RecordMap{
+			"tag1": types.String("tagvalue1"),
+		}),
+	}
+
+	tests := []struct {
+		name   string
+		entity types.Entity
+		other  types.Entity
+		want   bool
+	}{
+		{
+			name:   "same content",
+			entity: baseEntity,
+			other:  baseEntity,
+			want:   true,
+		},
+		{
+			name:   "different UID",
+			entity: baseEntity,
+			other: types.Entity{
+				UID:        types.NewEntityUID("FooType", "2"),
+				Parents:    baseEntity.Parents,
+				Attributes: baseEntity.Attributes,
+				Tags:       baseEntity.Tags,
+			},
+			want: false,
+		},
+		{
+			name:   "different parents",
+			entity: baseEntity,
+			other: types.Entity{
+				UID: baseEntity.UID,
+				Parents: types.NewEntityUIDSet(
+					types.NewEntityUID("BarType", "1"),
+					types.NewEntityUID("DifferentType", "2"),
+				),
+				Attributes: baseEntity.Attributes,
+				Tags:       baseEntity.Tags,
+			},
+			want: false,
+		},
+		{
+			name:   "different attributes",
+			entity: baseEntity,
+			other: types.Entity{
+				UID:     baseEntity.UID,
+				Parents: baseEntity.Parents,
+				Attributes: types.NewRecord(types.RecordMap{
+					"attr1": types.String("different_value"),
+					"attr2": types.Long(42),
+				}),
+				Tags: baseEntity.Tags,
+			},
+			want: false,
+		},
+		{
+			name:   "different tags",
+			entity: baseEntity,
+			other: types.Entity{
+				UID:        baseEntity.UID,
+				Parents:    baseEntity.Parents,
+				Attributes: baseEntity.Attributes,
+				Tags: types.NewRecord(types.RecordMap{
+					"tag1": types.String("different_tagvalue"),
+				}),
+			},
+			want: false,
+		},
+		{
+			name:   "empty entities",
+			entity: types.Entity{},
+			other:  types.Entity{},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testutil.Equals(t, tt.entity.Equal(tt.other), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Having an implementation of Equal() adds a canonical method of checking for Entity equality and makes it compatible with the cmp package's [Equal()](https://pkg.go.dev/github.com/google/go-cmp/cmp#Equal) function and other types in this package (e.g. Record, EntityUID).
