### PR TITLE
cedar-go: ignore var-naming revive lint errors in the types package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,8 +33,11 @@ linters:
           - revive
         text: exported
 
-      # The types package seems reasonably named to me
-      - path: types/
-        linters:
-          - revive
-        text: var-naming
+  settings:
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - []
+            - []
+            - - skip-package-name-checks: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,9 @@ linters:
         linters:
           - revive
         text: exported
+
+      # The types package seems reasonably named to me
+      - path: types/
+        linters:
+          - revive
+        text: var-naming


### PR DESCRIPTION
Addresses #94

A change in the linters is blocking a contributor's PR.

