### PR TITLE
expose partial eval functions

### DIFF
--- a/x/exp/eval/eval.go
+++ b/x/exp/eval/eval.go
@@ -15,3 +15,24 @@ func Eval(n ast.IsNode, env Env) (types.Value, error) {
 	evaler := eval.ToEval(n)
 	return evaler.Eval(env)
 }
+
+// Variable is a variable in the policy.
+var Variable = eval.Variable
+
+// Ignore is a special value that is used to ignore a value.
+var Ignore = eval.Ignore
+
+// IsVariable checks if a value is a variable.
+var IsVariable = eval.IsVariable
+
+// IsIgnore checks if a value is an ignore value.
+var IsIgnore = eval.IsIgnore
+
+// ToVariable converts a value to a variable.
+var ToVariable = eval.ToVariable
+
+// TypeName returns the type name of a value.
+var TypeName = eval.TypeName
+
+// ErrType is the error type for type errors.
+var ErrType = eval.ErrType


### PR DESCRIPTION
expose  eval.Variable， eval.Ignore to use in third-party, keep identity with cedar-go in unknow represent


