### PR TITLE
internal/schema/parser: support Path type in context decl

### DIFF
--- a/internal/schema/ast/ast.go
+++ b/internal/schema/ast/ast.go
@@ -22,7 +22,7 @@ import (
 // AttrDecls := Name ['?'] ':' Type [',' | ',' AttrDecls]
 // AppliesTo := 'appliesTo' '{' AppDecls '}'
 // AppDecls  := ('principal' | 'resource') ':' EntOrTyps [',' | ',' AppDecls]
-//            | 'context' ':' RecType [',' | ',' AppDecls]
+//            | 'context' ':' (Path | RecType) [',' | ',' AppDecls]
 // Path      := IDENT {'::' IDENT}
 // Ref       := Path '::' STR | Name
 // RefOrRefs := Ref | '[' [RefOrRefs] ']'
@@ -339,9 +339,10 @@ type AppliesTo struct {
 	AppliesToTok token.Position
 	CloseBrace   token.Position
 
-	Principal []*Path // one of required
-	Resource  []*Path
-	Context   *RecordType // nil if none
+	Principal     []*Path // one of required
+	Resource      []*Path
+	ContextPath   *Path       // nil if none
+	ContextRecord *RecordType // nil if none
 
 	Inline            *Comment // after {
 	PrincipalComments NodeComments

--- a/internal/schema/ast/convert_human.go
+++ b/internal/schema/ast/convert_human.go
@@ -66,8 +66,10 @@ func convertNamespace(n *Namespace) *JSONNamespace {
 					for _, res := range astDecl.AppliesTo.Resource {
 						jsAction.AppliesTo.ResourceTypes = append(jsAction.AppliesTo.ResourceTypes, res.String())
 					}
-					if astDecl.AppliesTo.Context != nil {
-						jsAction.AppliesTo.Context = convertType(astDecl.AppliesTo.Context)
+					if astDecl.AppliesTo.ContextRecord != nil {
+						jsAction.AppliesTo.Context = convertType(astDecl.AppliesTo.ContextRecord)
+					} else if astDecl.AppliesTo.ContextPath != nil {
+						jsAction.AppliesTo.Context = convertType(astDecl.AppliesTo.ContextPath)
 					}
 				}
 				jsNamespace.Actions[astActionName.String()] = jsAction

--- a/internal/schema/ast/convert_json.go
+++ b/internal/schema/ast/convert_json.go
@@ -187,8 +187,11 @@ func convertJSONAppliesTo(appliesTo *JSONAppliesTo) *AppliesTo {
 
 	// Convert context
 	if appliesTo.Context != nil {
-		if context, ok := convertJSONType(appliesTo.Context).(*RecordType); ok {
-			at.Context = context
+		switch t := convertJSONType(appliesTo.Context).(type) {
+		case *RecordType:
+			at.ContextRecord = t
+		case *Path:
+			at.ContextPath = t
 		}
 	}
 

--- a/internal/schema/ast/format.go
+++ b/internal/schema/ast/format.go
@@ -302,10 +302,14 @@ func (p *formatter) printAppliesTo(n *AppliesTo) {
 		}
 		p.write("\n")
 	}
-	if n.Context != nil {
+	if n.ContextRecord != nil || n.ContextPath != nil {
 		p.print(n.ContextComments.Before)
 		p.printInd("context: ")
-		p.print(n.Context)
+		if n.ContextRecord != nil {
+			p.print(n.ContextRecord)
+		} else {
+			p.print(n.ContextPath)
+		}
 		p.write(",")
 		if n.ContextComments.Inline != nil {
 			p.print(n.ContextComments.Inline)

--- a/internal/schema/ast/testdata/convert/test.cedarschema
+++ b/internal/schema/ast/testdata/convert/test.cedarschema
@@ -40,18 +40,17 @@ namespace PhotoFlash {
       },
     }
   };
+  type authenticatedContext = {
+    "authenticated": Bool,
+  };
   action "viewPhoto" in [groupAction1, groupAction2, random::nested::name::"actionGroup"] appliesTo {
     principal: User,
     resource: Photo,
-    context: {
-      "authenticated": Bool,
-    }
+    context: authenticatedContext,
   };
   action "listAlbums" appliesTo {
     principal: User,
     resource: Account,
-    context: {
-      "authenticated": Bool,
-    }
+    context: authenticatedContext,
   };
 }

--- a/internal/schema/ast/testdata/convert/test_want.json
+++ b/internal/schema/ast/testdata/convert/test_want.json
@@ -20,6 +20,15 @@
           "annotation1": "type",
           "annotation2": "type"
         }
+      },
+      "authenticatedContext": {
+        "type": "Record",
+        "attributes": {
+          "authenticated": {
+            "type": "Boolean",
+            "required": true
+          }
+        }
       }
     },
     "entityTypes": {
@@ -162,13 +171,8 @@
             "User"
           ],
           "context": {
-            "type": "Record",
-            "attributes": {
-              "authenticated": {
-                "required": true,
-                "type": "Boolean"
-              }
-            }
+            "type": "EntityOrCommon",
+            "name": "authenticatedContext"
           }
         }
       },
@@ -219,13 +223,8 @@
             "User"
           ],
           "context": {
-            "type": "Record",
-            "attributes": {
-              "authenticated": {
-                "required": true,
-                "type": "Boolean"
-              }
-            }
+            "type": "EntityOrCommon",
+            "name": "authenticatedContext"
           }
         },
         "memberOf": [

--- a/internal/schema/ast/testdata/format/test.cedarschema
+++ b/internal/schema/ast/testdata/format/test.cedarschema
@@ -67,13 +67,14 @@ namespace PhotoFlash { // inline namespace comment
       "authenticated": Bool, // attribute comment inline
     }, // context comment
   };
+  type authenticatedContext = {
+    "authenticated": Bool,
+    appliesTo: String, // keywords are valid identifiers
+  };
   action "listAlbums" in "read" appliesTo {
     principal: User,
     resource: Account,
-    context: {
-      "authenticated": Bool,
-      appliesTo: String, // keywords are valid identifiers
-    },
+    context: authenticatedContext,
   };
   // Remainder comment block
   // should also be kept around

--- a/internal/schema/ast/walk_test.go
+++ b/internal/schema/ast/walk_test.go
@@ -178,8 +178,11 @@ func (vis *visitor) walk(n ast.Node, open, exit func(ast.Node) bool) {
 		for _, r := range v.Resource {
 			vis.walk(r, open, exit)
 		}
-		if v.Context != nil {
-			vis.walk(v.Context, open, exit)
+		if v.ContextRecord != nil {
+			vis.walk(v.ContextRecord, open, exit)
+		}
+		if v.ContextPath != nil {
+			vis.walk(v.ContextPath, open, exit)
 		}
 	case *ast.RecordType:
 		for _, attr := range v.Attributes {

--- a/internal/schema/parser/parser.go
+++ b/internal/schema/parser/parser.go
@@ -346,9 +346,14 @@ loop:
 		case token.CONTEXT:
 			p.eat()
 			p.eatOnly(token.COLON, "expected :")
-			appliesTo.Context = p.parseRecType()
+			if p.peek().Type == token.LEFTBRACE {
+				appliesTo.ContextRecord = p.parseRecType()
+				node = appliesTo.ContextRecord
+			} else {
+				appliesTo.ContextPath = p.parsePath()
+				node = appliesTo.ContextPath
+			}
 			nodeComments = &appliesTo.ContextComments
-			node = appliesTo.Context
 		case token.COMMENT:
 			comments = append(comments, p.parseComment())
 			continue

--- a/internal/schema/parser/testdata/cases/example.cedarschema
+++ b/internal/schema/parser/testdata/cases/example.cedarschema
@@ -77,6 +77,15 @@ namespace PhotoFlash { // inline namespace comment
       appliesTo: String, // keywords are valid identifiers
     },
   };
+  type commonContext = {
+    "authenticated": Bool,
+    appliesTo: String, // keywords are valid identifiers
+  };
+  action "commonContext" appliesTo {
+    principal: User,
+    resource: Account,
+    context: commonContext,
+  };
   // Remainder comment block
   // should also be kept around
 } // Footer comment on namespace


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Although not officially documented in the [Cedar schema grammar](https://docs.cedarpolicy.com/schema/human-readable-schema-grammar.html), `Path`s are allowed to be specified for the type of the context for an action. For example:

```
type commonContext = {
    now: __cedar::datetime,
    origin: __cedar::ipaddr,
};

action edit appliesTo {
    principal: User,
    resource: Document,
    context: commonContext,
};
```

