### PR TITLE
internal/parser: move testing of trailing commas into parser package

### DIFF
--- a/internal/parser/cedar_unmarshal_test.go
+++ b/internal/parser/cedar_unmarshal_test.go
@@ -491,6 +491,31 @@ when { (if true then 2 else 3) * 4 == 8 };`,
 	}
 }
 
+func TestParseTrailingCommas(t *testing.T) {
+	t.Parallel()
+	parseTests := []struct {
+		Name           string
+		Text           string
+		ExpectedPolicy *ast.Policy
+	}{
+		{
+			"after resource",
+			"permit (principal, action, resource,);",
+			ast.Permit(),
+		},
+	}
+
+	for _, tt := range parseTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			var policy parser.Policy
+			testutil.OK(t, policy.UnmarshalCedar([]byte(tt.Text)))
+			tt.ExpectedPolicy.Position = ast.Position{Line: 1, Column: 1}
+			testutil.Equals(t, &policy, (*parser.Policy)(tt.ExpectedPolicy))
+		})
+	}
+}
+
 func TestParsePolicySetErrors(t *testing.T) {
 	t.Parallel()
 	parseTests := []struct {
@@ -590,7 +615,7 @@ func TestParsePolicySet(t *testing.T) {
 		policyStr := []byte(`permit (
 			principal,
 			action,
-			resource,
+			resource
 		);`)
 
 		var policies parser.PolicySlice

--- a/policy_test.go
+++ b/policy_test.go
@@ -84,29 +84,6 @@ when { resource.owner == principal };`
 	testutil.Equals(t, string(policy.MarshalCedar()), policyStr)
 }
 
-func TestPolicyCedar_TrailingComma(t *testing.T) {
-	t.Parallel()
-
-	const policyStr = `permit (
-    principal,
-    action == Action::"editPhoto",
-    resource
-)
-when { resource.owner == principal };`
-
-	const policyStrTrailingComma = `permit (
-    principal,
-    action == Action::"editPhoto",
-    resource,
-)
-when { resource.owner == principal };`
-
-	var policy cedar.Policy
-	testutil.OK(t, policy.UnmarshalCedar([]byte(policyStrTrailingComma)))
-
-	testutil.Equals(t, string(policy.MarshalCedar()), policyStr)
-}
-
 func TestPolicyAST(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/cedar-policy/cedar-go/issues/103

*Description of changes:*

Move tests closer to the code under test. As we add more support for trailing commas, additional testing can be added here.


