### PR TITLE
Add gochecksumtype and check Name in .../schema/ast/ast.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
   enable:
     - errcheck
     - errname
+    - gochecksumtype
     - govet
     - ineffassign
     - revive

--- a/internal/schema/ast/ast.go
+++ b/internal/schema/ast/ast.go
@@ -377,6 +377,8 @@ func (r *Ref) End() token.Position {
 }
 
 // Name is an IDENT or STR
+//
+//sumtype:decl
 type Name interface {
 	Node
 	isName()


### PR DESCRIPTION
gochecksumtype is a linter in golangci-lint that checks for switch statement exhaustiveness for types that look like sum types in other languages. More precisely, interface types with a //sumtype:decl annotation and an unexported nullary marker method are statically guaranteed to be closed (since new types that implement the interface can't be created). This means that we can check for exhaustiveness on type switches for values implementing the sumdecl-compatible interface, which is what the linter does.

The initial attempt to add this to every type with a marker interface https://github.com/cedar-policy/cedar-go/pull/111 has grown in complexity since a few of the tests use unknownNode and unknownType types for checking the error paths. gochecksumtype has no way of indicating test-only variants of a sum type. So, to keep the diff size small and the code coverage at 100% (except for the generated parser) at each step, I'm going to break PR #111 into pieces and land them separately.


