### PR TITLE
Add sumtype:decl to Declaration type

### DIFF
--- a/internal/schema/ast/ast.go
+++ b/internal/schema/ast/ast.go
@@ -97,6 +97,7 @@ func (s *Schema) End() token.Position {
 	return token.Position{}
 }
 
+//sumtype:decl
 type Declaration interface {
 	Node
 	isDecl()

--- a/internal/schema/ast/convert_json_test.go
+++ b/internal/schema/ast/convert_json_test.go
@@ -29,7 +29,10 @@ func TestConvertJsonToHumanRoundtrip(t *testing.T) {
 
 	// Convert to human-readable format and back to JSON
 	humanSchema := ast.ConvertJSON2Human(jsonSchema)
-	jsonSchema2 := ast.ConvertHuman2JSON(humanSchema)
+	jsonSchema2, err := ast.ConvertHuman2JSON(humanSchema)
+	if err != nil {
+		t.Fatalf("Error dumping schema: %v", err)
+	}
 
 	// Compare the JSON schemas
 	json1, err := json.MarshalIndent(jsonSchema, "", "    ")
@@ -90,5 +93,28 @@ func TestConvertJsonToHumanInvalidType(t *testing.T) {
 	expected := "unknown JSON type: InvalidType"
 	if !strings.Contains(panicMsg, expected) {
 		t.Errorf("expected panic message to contain %q, got %q", expected, panicMsg)
+	}
+}
+
+func TestConvertHuman2JSON_NestedNamespace(t *testing.T) {
+	namePath := &ast.Path{Parts: []*ast.Ident{{Value: "hi"}}}
+	innerNamespace := &ast.Namespace{
+		Name: namePath,
+	}
+	outerNamespace := &ast.Namespace{
+		Name: namePath,
+		Decls: []ast.Declaration{
+			innerNamespace,
+		},
+	}
+	schema := &ast.Schema{
+		Decls: []ast.Declaration{
+			outerNamespace,
+		},
+	}
+
+	_, err := ast.ConvertHuman2JSON(schema)
+	if err == nil {
+		t.Errorf("should have failed")
 	}
 }

--- a/x/exp/schema/schema.go
+++ b/x/exp/schema/schema.go
@@ -69,7 +69,11 @@ func (s *Schema) MarshalJSON() (out []byte, err error) {
 	if s.humanSchema != nil {
 		// Error should not be possible since s.humanSchema comes from our parser.
 		// If it happens, we return empty JSON.
-		s.jsonSchema = ast.ConvertHuman2JSON(s.humanSchema)
+		schema, err := ast.ConvertHuman2JSON(s.humanSchema)
+		if err != nil {
+			return nil, err
+		}
+		s.jsonSchema = schema
 	}
 	if s.jsonSchema == nil {
 		return nil, nil

--- a/x/exp/schema/schema_test.go
+++ b/x/exp/schema/schema_test.go
@@ -3,7 +3,10 @@ package schema
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/cedar-policy/cedar-go/internal/schema/ast"
 )
 
 func TestSchemaCedarMarshalUnmarshal(t *testing.T) {
@@ -103,6 +106,29 @@ func TestSchemaJSONMarshalEmpty(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Errorf("MarshalJSON() produced non-empty output for empty schema")
+	}
+}
+
+func TestSchemaJSONMarshalNestedNamespace(t *testing.T) {
+	var s Schema
+	s.humanSchema = &ast.Schema{
+		Decls: []ast.Declaration{
+			&ast.Namespace{
+				Name: &ast.Path{Parts: []*ast.Ident{{Value: "hi"}}},
+				Decls: []ast.Declaration{
+					&ast.Namespace{
+						Name: &ast.Path{Parts: []*ast.Ident{{Value: "hi"}}},
+					},
+				},
+			},
+		},
+	}
+	_, err := s.MarshalJSON()
+	if err == nil {
+		t.Error("error should not be nil")
+	}
+	if !strings.Contains(err.Error(), "namespace") {
+		t.Errorf("bad non-namespace-related error: %v", err)
 	}
 }
 


### PR DESCRIPTION
We also need to fix up one location `convertNamespace` which handles nested namespaces. Nested namespaces are not valid (and don't even parse), but here I'm handling them with an error rather than a panic.

This leads to some changes in functions that transitively call convertNamespace.

*Issue #, if available:*

sumtype:decl extracted from PR below (but the other code changes are not)
https://github.com/cedar-policy/cedar-go/pull/111


