### PR TITLE
x/exp/schema: fix reserved keyword handling and add validation

### DIFF
--- a/internal/parser/cedar_tokenize.go
+++ b/internal/parser/cedar_tokenize.go
@@ -36,9 +36,12 @@ type Token struct {
 	Text string
 }
 
-// N.B. "is" is included here for compatibility with the Rust implementation. The Cedar specification does not list
-// "is" as a reserved keyword
-var reservedKeywords = []string{"true", "false", "if", "then", "else", "in", "like", "has", "is"}
+var reservedKeywords = []string{"true", "false", "if", "then", "else", "in", "like", "has", "is", "__cedar"}
+
+// IsReservedKeyword reports whether s is a reserved Cedar keyword.
+func IsReservedKeyword(s string) bool {
+	return slices.Contains(reservedKeywords, s)
+}
 
 func (t Token) isEOF() bool {
 	return t.Type == TokenEOF
@@ -488,7 +491,7 @@ redo:
 
 	// last minute check for reserved keywords
 	text := s.tokenText()
-	if tt == TokenIdent && slices.Contains(reservedKeywords, text) {
+	if tt == TokenIdent && IsReservedKeyword(text) {
 		tt = TokenReservedKeyword
 	}
 

--- a/x/exp/schema/internal/parser/marshal.go
+++ b/x/exp/schema/internal/parser/marshal.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	cedarparser "github.com/cedar-policy/cedar-go/internal/parser"
 	"github.com/cedar-policy/cedar-go/types"
 	"github.com/cedar-policy/cedar-go/x/exp/schema/ast"
 )
@@ -311,7 +312,7 @@ func isValidIdent(s string) bool {
 			}
 		}
 	}
-	return true
+	return !cedarparser.IsReservedKeyword(s)
 }
 
 // quoteCedar produces a double-quoted string literal using only Cedar-valid

--- a/x/exp/schema/internal/parser/parser_internal_test.go
+++ b/x/exp/schema/internal/parser/parser_internal_test.go
@@ -137,6 +137,7 @@ func TestTokenName(t *testing.T) {
 		{tokenDoubleColon, "'::'"},
 		{tokenQuestion, "'?'"},
 		{tokenEquals, "'='"},
+		{tokenReservedKeyword, "reserved keyword"},
 		{tokenType(999), "unknown"},
 	}
 	for _, tt := range tests {
@@ -158,6 +159,8 @@ func TestIsValidIdent(t *testing.T) {
 	testutil.Equals(t, isValidIdent(""), false)
 	testutil.Equals(t, isValidIdent("1abc"), false)
 	testutil.Equals(t, isValidIdent("foo bar"), false)
+	testutil.Equals(t, isValidIdent("in"), false)
+	testutil.Equals(t, isValidIdent("__cedar"), false)
 }
 
 func TestLexerBadStringEscape(t *testing.T) {

--- a/x/exp/schema/internal/parser/token.go
+++ b/x/exp/schema/internal/parser/token.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"unicode/utf8"
 
+	cedarparser "github.com/cedar-policy/cedar-go/internal/parser"
 	"github.com/cedar-policy/cedar-go/internal/rust"
 )
 
@@ -28,6 +29,7 @@ const (
 	tokenDoubleColon
 	tokenQuestion
 	tokenEquals
+	tokenReservedKeyword
 )
 
 type position struct {
@@ -202,7 +204,11 @@ func (l *lexer) next() (token, error) {
 
 	if isIdentStart(r) {
 		text := l.scanIdent()
-		return token{Type: tokenIdent, Pos: pos, Text: text}, nil
+		tt := tokenIdent
+		if cedarparser.IsReservedKeyword(text) {
+			tt = tokenReservedKeyword
+		}
+		return token{Type: tt, Pos: pos, Text: text}, nil
 	}
 
 	if r == '"' {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a tokenReservedKeyword token type to the schema parser's lexer, matching the approach used in the main Cedar parser. Previously, reserved keywords like "true", "false", "in", "if", etc. were lexed as plain identifiers, which meant the parser silently accepted them in positions where they should be rejected (e.g. `entity true;`, `type if = String;`).

Bugs fixed:
- Reserved Cedar keywords were accepted as entity, type, and action names, namespace path components, and attribute names without quoting. The parser now rejects these with a clear error message.
- `__cedar` as a definition name (entity, type, enum) was silently accepted. These are now rejected while still allowing `__cedar` as an action name, attribute name, and type reference prefix, which matches the Cedar Rust behavior.
- Duplicate annotations (e.g. `@doc("a") @doc("b")`) were silently accepted with last-wins semantics. The parser now rejects duplicates.
- Duplicate `principal`, `resource`, or `context` declarations within `appliesTo` were silently accepted. The parser now rejects duplicates.
- Empty `principal` or `resource` type lists in `appliesTo` (e.g.  `principal: []`) were silently accepted, producing a meaningless empty list. The parser now rejects these.
- `appliesTo` blocks missing a `principal` or `resource` declaration were accepted. The parser now requires both.
- `MarshalSchema()` emitted reserved keywords as bare identifiers in attribute and action names (e.g. `true: String`), producing output that could not be re-parsed. `isValidIdent()` now checks for reserved keywords and the marshaler quotes them.

