### PR TITLE
types: add stronger types and helpers for inspecting Paths and Path derivatives

### DIFF
--- a/types/entity_uid.go
+++ b/types/entity_uid.go
@@ -14,8 +14,44 @@ import (
 // Path is a series of idents separated by ::
 type Path string
 
+// IsQualified returns whether a Path has any qualifiers (i.e. at least one ::)
+func (p Path) IsQualified() bool {
+	return strings.Contains(string(p), "::")
+}
+
+// Qualifier returns a Path with everything but the last element in the original Path or "" if there is only one element.
+func (p Path) Qualifier() Path {
+	idx := strings.LastIndex(string(p), "::")
+	if idx == -1 {
+		return ""
+	}
+	return p[:idx]
+}
+
+// Basename returns the last element in the Path
+func (p Path) Basename() string {
+	idx := strings.LastIndex(string(p), "::")
+	if idx == -1 {
+		return string(p)
+	}
+	return string(p[idx+2:])
+}
+
+// Namespace is a type of Path whose basename does not refer to a type
+type Namespace Path
+
 // EntityType is the type portion of an EntityUID
 type EntityType Path
+
+// Namespace returns the namespace for the EntityType or "" if the type has no namespace.
+func (e EntityType) Namespace() Namespace {
+	return Namespace(Path(e).Qualifier())
+}
+
+// Basename returns the unqualified entity type name.
+func (e EntityType) Basename() string {
+	return Path(e).Basename()
+}
 
 // An EntityUID is the identifier for a principal, action, or resource.
 type EntityUID struct {

--- a/types/entity_uid_test.go
+++ b/types/entity_uid_test.go
@@ -113,6 +113,46 @@ func TestEntity(t *testing.T) {
 	})
 }
 
+func TestPathQualification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path      types.Path
+		qualified bool
+		qualifier types.Path
+		basename  string
+	}{
+		{"NS::User", true, "NS", "User"},
+		{"A::B::C", true, "A::B", "C"},
+		{"User", false, "", "User"},
+		{"", false, "", ""},
+	}
+	for _, tt := range tests {
+		testutil.Equals(t, tt.path.IsQualified(), tt.qualified)
+		testutil.Equals(t, tt.path.Qualifier(), tt.qualifier)
+		testutil.Equals(t, tt.path.Basename(), tt.basename)
+	}
+}
+
+func TestEntityTypeQualification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		typ       types.EntityType
+		qualified bool
+		namespace types.Namespace
+		basename  string
+	}{
+		{"NS::User", true, "NS", "User"},
+		{"A::B::C", true, "A::B", "C"},
+		{"User", false, "", "User"},
+	}
+	for _, tt := range tests {
+		testutil.Equals(t, tt.typ.Namespace(), tt.namespace)
+		testutil.Equals(t, tt.typ.Basename(), tt.basename)
+	}
+}
+
 func TestEntityUIDSet(t *testing.T) {
 	t.Parallel()
 

--- a/x/exp/schema/ast/ast.go
+++ b/x/exp/schema/ast/ast.go
@@ -21,7 +21,7 @@ type Actions map[types.String]Action
 type CommonTypes map[types.Ident]CommonType
 
 // Namespaces maps namespace paths to their definitions.
-type Namespaces map[types.Path]Namespace
+type Namespaces map[types.Namespace]Namespace
 
 // Schema is the top-level Cedar schema AST.
 // The Entities, Enums, Actions, and CommonTypes are for the top-level namespace.

--- a/x/exp/schema/ast/ast_test.go
+++ b/x/exp/schema/ast/ast_test.go
@@ -21,6 +21,30 @@ func TestConstructors(t *testing.T) {
 	testutil.Equals(t, ast.Type("MyType"), ast.TypeRef("MyType"))
 }
 
+func TestEntityTypeRefQualification(t *testing.T) {
+	qualified := ast.EntityTypeRef("NS::User")
+	testutil.Equals(t, qualified.IsQualified(), true)
+	testutil.Equals(t, qualified.Namespace(), types.Namespace("NS"))
+	testutil.Equals(t, qualified.Basename(), "User")
+
+	unqualified := ast.EntityTypeRef("User")
+	testutil.Equals(t, unqualified.IsQualified(), false)
+	testutil.Equals(t, unqualified.Namespace(), types.Namespace(""))
+	testutil.Equals(t, unqualified.Basename(), "User")
+}
+
+func TestTypeRefQualification(t *testing.T) {
+	qualified := ast.TypeRef("NS::MyType")
+	testutil.Equals(t, qualified.IsQualified(), true)
+	testutil.Equals(t, qualified.Namespace(), types.Namespace("NS"))
+	testutil.Equals(t, qualified.Basename(), "MyType")
+
+	unqualified := ast.TypeRef("MyType")
+	testutil.Equals(t, unqualified.IsQualified(), false)
+	testutil.Equals(t, unqualified.Namespace(), types.Namespace(""))
+	testutil.Equals(t, unqualified.Basename(), "MyType")
+}
+
 func TestParentRefFromID(t *testing.T) {
 	ref := ast.ParentRefFromID("view")
 	testutil.Equals(t, ref.ID, types.String("view"))

--- a/x/exp/schema/ast/types.go
+++ b/x/exp/schema/ast/types.go
@@ -81,6 +81,21 @@ type EntityTypeRef types.EntityType
 
 func (EntityTypeRef) isType() { _ = 0 }
 
+// IsQualified reports whether the entity type reference contains a namespace qualifier.
+func (e EntityTypeRef) IsQualified() bool {
+	return types.EntityType(e).Namespace() != ""
+}
+
+// Namespace returns the namespace portion of a qualified entity type reference, or "" if unqualified.
+func (e EntityTypeRef) Namespace() types.Namespace {
+	return types.Namespace(types.Path(e).Qualifier())
+}
+
+// Basename returns the unqualified entity type name.
+func (e EntityTypeRef) Basename() string {
+	return types.EntityType(e).Basename()
+}
+
 // EntityType returns an EntityTypeRef for the given entity type name.
 func EntityType(name types.EntityType) EntityTypeRef {
 	return EntityTypeRef(name)
@@ -90,6 +105,21 @@ func EntityType(name types.EntityType) EntityTypeRef {
 type TypeRef types.Path
 
 func (TypeRef) isType() { _ = 0 }
+
+// IsQualified reports whether the type reference contains a namespace qualifier.
+func (t TypeRef) IsQualified() bool {
+	return types.Path(t).IsQualified()
+}
+
+// Namespace returns the namespace portion of a qualified type reference, or "" if unqualified.
+func (t TypeRef) Namespace() types.Namespace {
+	return types.Namespace(types.Path(t).Qualifier())
+}
+
+// Basename returns the unqualified type name.
+func (t TypeRef) Basename() string {
+	return types.Path(t).Basename()
+}
 
 // Type returns a TypeRef for the given path.
 func Type(name types.Path) TypeRef {

--- a/x/exp/schema/internal/json/json.go
+++ b/x/exp/schema/internal/json/json.go
@@ -19,7 +19,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 
 	// Bare declarations go under the empty string key.
 	if hasBareDecls((*ast.Schema)(s)) {
-		ns, err := marshalNamespace("", ast.Namespace{
+		ns, err := marshalNamespace(ast.Namespace{
 			Entities:    s.Entities,
 			Enums:       s.Enums,
 			Actions:     s.Actions,
@@ -32,7 +32,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 	}
 
 	for name, ns := range s.Namespaces {
-		jns, err := marshalNamespace(name, ns)
+		jns, err := marshalNamespace(ns)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +67,7 @@ func (s *Schema) UnmarshalJSON(b []byte) error {
 			if result.Namespaces == nil {
 				result.Namespaces = ast.Namespaces{}
 			}
-			result.Namespaces[types.Path(name)] = ns
+			result.Namespaces[types.Namespace(name)] = ns
 		}
 	}
 	*s = Schema(result)
@@ -131,7 +131,7 @@ type jsonAttr struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-func marshalNamespace(name types.Path, ns ast.Namespace) (jsonNamespace, error) {
+func marshalNamespace(ns ast.Namespace) (jsonNamespace, error) {
 	jns := jsonNamespace{
 		EntityTypes: make(map[string]jsonEntityType),
 		Actions:     make(map[string]jsonAction),

--- a/x/exp/schema/internal/json/json_internal_test.go
+++ b/x/exp/schema/internal/json/json_internal_test.go
@@ -26,7 +26,7 @@ func TestMarshalRecordTypeError(t *testing.T) {
 }
 
 func TestMarshalNamespaceCommonTypeError(t *testing.T) {
-	_, err := marshalNamespace("", ast.Namespace{
+	_, err := marshalNamespace(ast.Namespace{
 		CommonTypes: ast.CommonTypes{
 			"Bad": ast.CommonType{Type: nil},
 		},
@@ -35,7 +35,7 @@ func TestMarshalNamespaceCommonTypeError(t *testing.T) {
 }
 
 func TestMarshalNamespaceEntityShapeError(t *testing.T) {
-	_, err := marshalNamespace("", ast.Namespace{
+	_, err := marshalNamespace(ast.Namespace{
 		Entities: ast.Entities{
 			"Foo": ast.Entity{
 				Shape: ast.RecordType{
@@ -50,7 +50,7 @@ func TestMarshalNamespaceEntityShapeError(t *testing.T) {
 func TestMarshalNamespaceEntityTagsError(t *testing.T) {
 	// Tags is nil, but the code checks `entity.Tags != nil` first
 	// So we need a non-nil tags that fails. Use SetType{Element: nil}.
-	_, err := marshalNamespace("", ast.Namespace{
+	_, err := marshalNamespace(ast.Namespace{
 		Entities: ast.Entities{
 			"Foo": ast.Entity{Tags: nil},
 		},
@@ -59,7 +59,7 @@ func TestMarshalNamespaceEntityTagsError(t *testing.T) {
 }
 
 func TestMarshalNamespaceEntityTagsError2(t *testing.T) {
-	_, err := marshalNamespace("", ast.Namespace{
+	_, err := marshalNamespace(ast.Namespace{
 		Entities: ast.Entities{
 			"Foo": ast.Entity{Tags: ast.SetType{Element: nil}},
 		},
@@ -68,7 +68,7 @@ func TestMarshalNamespaceEntityTagsError2(t *testing.T) {
 }
 
 func TestMarshalNamespaceActionAnnotations(t *testing.T) {
-	ns, err := marshalNamespace("", ast.Namespace{
+	ns, err := marshalNamespace(ast.Namespace{
 		Actions: ast.Actions{
 			"view": ast.Action{
 				Annotations: ast.Annotations{"doc": "test"},
@@ -80,7 +80,7 @@ func TestMarshalNamespaceActionAnnotations(t *testing.T) {
 }
 
 func TestMarshalNamespaceContextError(t *testing.T) {
-	_, err := marshalNamespace("", ast.Namespace{
+	_, err := marshalNamespace(ast.Namespace{
 		Actions: ast.Actions{
 			"view": ast.Action{
 				AppliesTo: &ast.AppliesTo{

--- a/x/exp/schema/internal/parser/parser.go
+++ b/x/exp/schema/internal/parser/parser.go
@@ -141,7 +141,7 @@ func (p *parser) parseSchema() (*ast.Schema, error) {
 }
 
 type parsedNamespace struct {
-	name types.Path
+	name types.Namespace
 	ns   ast.Namespace
 }
 
@@ -150,7 +150,8 @@ func (p *parser) parseNamespace(annotations ast.Annotations) (parsedNamespace, e
 	if err != nil {
 		return parsedNamespace{}, err
 	}
-	if slices.Contains(strings.Split(string(path), "::"), "__cedar") {
+	nsName := types.Namespace(path)
+	if slices.Contains(strings.Split(string(nsName), "::"), "__cedar") {
 		return parsedNamespace{}, fmt.Errorf("%s: the name %q contains \"__cedar\", which is reserved", p.tok.Pos, path)
 	}
 	if err := p.expect(tokenLBrace); err != nil {
@@ -177,7 +178,7 @@ func (p *parser) parseNamespace(annotations ast.Annotations) (parsedNamespace, e
 	ns.Enums = innerSchema.Enums
 	ns.Actions = innerSchema.Actions
 	ns.CommonTypes = innerSchema.CommonTypes
-	return parsedNamespace{name: path, ns: ns}, nil
+	return parsedNamespace{name: nsName, ns: ns}, nil
 }
 
 func (p *parser) parseDecl(annotations ast.Annotations, schema *ast.Schema) error {

--- a/x/exp/schema/resolved/resolve_internal_test.go
+++ b/x/exp/schema/resolved/resolve_internal_test.go
@@ -13,7 +13,7 @@ func TestResolveTypeDefault(t *testing.T) {
 	r := &resolverState{
 		entityTypes: make(map[types.EntityType]bool),
 		enumTypes:   make(map[types.EntityType]bool),
-		commonTypes: make(map[types.Path]ast.IsType),
+		commonTypes: make(map[commonType]ast.IsType),
 	}
 	testutil.Panic(t, func() {
 		_, _ = r.resolveType("", nil)
@@ -22,7 +22,7 @@ func TestResolveTypeDefault(t *testing.T) {
 
 func TestResolveTypePath(t *testing.T) {
 	r := &resolverState{
-		commonTypes: map[types.Path]ast.IsType{
+		commonTypes: map[commonType]ast.IsType{
 			"NS::A": ast.StringType{},
 			"B":     ast.LongType{},
 		},
@@ -31,16 +31,16 @@ func TestResolveTypePath(t *testing.T) {
 	}
 
 	// __cedar:: prefix returns path unchanged
-	p := r.resolveTypeRefPath("NS", "__cedar::String")
-	testutil.Equals(t, p, types.Path("__cedar::String"))
+	p := r.resolveCommonTypeRefPath("NS", "__cedar::String")
+	testutil.Equals(t, p, "__cedar::String")
 
 	// Already qualified (contains ::) returns path unchanged
-	p = r.resolveTypeRefPath("NS", "Other::Foo")
-	testutil.Equals(t, p, types.Path("Other::Foo"))
+	p = r.resolveCommonTypeRefPath("NS", "Other::Foo")
+	testutil.Equals(t, p, "Other::Foo")
 
 	// Unqualified in namespace resolves to NS::A
-	p = r.resolveTypeRefPath("NS", "A")
-	testutil.Equals(t, p, types.Path("NS::A"))
+	p = r.resolveCommonTypeRefPath("NS", "A")
+	testutil.Equals(t, p, "NS::A")
 }
 
 func TestResolveActionParentRef(t *testing.T) {
@@ -69,7 +69,7 @@ func TestCollectTypeRefsDefault(t *testing.T) {
 func TestDetectCommonTypeCyclesBuiltinRef(t *testing.T) {
 	// Verify cycle detection works correctly with __cedar:: refs.
 	r := &resolverState{
-		commonTypes: map[types.Path]ast.IsType{
+		commonTypes: map[commonType]ast.IsType{
 			"NS::A": ast.TypeRef("__cedar::String"),
 		},
 		entityTypes: make(map[types.EntityType]bool),

--- a/x/exp/schema/resolved/resolve_test.go
+++ b/x/exp/schema/resolved/resolve_test.go
@@ -645,7 +645,7 @@ func TestResolveNamespaceOutput(t *testing.T) {
 	result, err := resolved.Resolve(s)
 	testutil.OK(t, err)
 	ns := result.Namespaces["NS"]
-	testutil.Equals(t, ns.Name, types.Path("NS"))
+	testutil.Equals(t, ns.Name, "NS")
 	testutil.Equals(t, types.String(ns.Annotations["doc"]), types.String("test"))
 }
 
@@ -1097,7 +1097,7 @@ func TestResolveUndefinedParents(t *testing.T) {
 }
 
 func TestResolveCedarBuiltinInTypePath(t *testing.T) {
-	// Exercise resolveTypeRefPath line 462-464: __cedar:: prefix in cycle detection.
+	// Exercise resolveCommonTypeRefPath line 462-464: __cedar:: prefix in cycle detection.
 	s := &ast.Schema{
 		CommonTypes: ast.CommonTypes{
 			"A": ast.CommonType{Type: ast.TypeRef("__cedar::String")},
@@ -1109,7 +1109,7 @@ func TestResolveCedarBuiltinInTypePath(t *testing.T) {
 }
 
 func TestResolveQualifiedTypePath(t *testing.T) {
-	// Exercise resolveTypeRefPath line 465-467: qualified path with :: in cycle detection.
+	// Exercise resolveCommonTypeRefPath line 465-467: qualified path with :: in cycle detection.
 	s := &ast.Schema{
 		Namespaces: ast.Namespaces{
 			"NS": ast.Namespace{
@@ -1126,7 +1126,7 @@ func TestResolveQualifiedTypePath(t *testing.T) {
 }
 
 func TestResolveNamespacedCommonTypePath(t *testing.T) {
-	// Exercise resolveTypeRefPath line 470-472: namespaced common type ref in cycle detection.
+	// Exercise resolveCommonTypeRefPath line 470-472: namespaced common type ref in cycle detection.
 	s := &ast.Schema{
 		Namespaces: ast.Namespaces{
 			"NS": ast.Namespace{

--- a/x/exp/schema/schema_test.go
+++ b/x/exp/schema/schema_test.go
@@ -469,7 +469,7 @@ var wantAST = &ast.Schema{
 // wantResolved is the expected resolved schema structure.
 // All type references have been fully qualified and common types inlined.
 var wantResolved = &resolved.Schema{
-	Namespaces: map[types.Path]resolved.Namespace{
+	Namespaces: map[types.Namespace]resolved.Namespace{
 		"MyApp": {
 			Name: "MyApp",
 			Annotations: resolved.Annotations{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now, instead of passing types.Paths around all over the place in the schema code, we can know that we've got a Namespace or a commonType or a EntityType and the code becomes easier to understand (IMO).

The new methods on Path and EntityType may also help cedar-go users write more understandable code.

