### PR TITLE
x/exp/schema/resolved: give Action an Entity attribute

### DIFF
--- a/x/exp/schema/resolved/resolve_test.go
+++ b/x/exp/schema/resolved/resolve_test.go
@@ -356,7 +356,7 @@ func TestResolveActionParents(t *testing.T) {
 	testutil.OK(t, err)
 	uid := types.NewEntityUID("Action", "view")
 	view := result.Actions[uid]
-	testutil.Equals(t, view.Parents, []types.EntityUID{types.NewEntityUID("Action", "readOnly")})
+	testutil.Equals(t, view.Entity.Parents, types.NewEntityUIDSet(types.NewEntityUID("Action", "readOnly")))
 }
 
 func TestResolveActionCycle(t *testing.T) {
@@ -482,7 +482,7 @@ func TestResolveActionQualifiedParent(t *testing.T) {
 	testutil.OK(t, err)
 	uid := types.NewEntityUID("NS::Action", "view")
 	view := result.Actions[uid]
-	testutil.Equals(t, view.Parents, []types.EntityUID{types.NewEntityUID("NS::Action", "readOnly")})
+	testutil.Equals(t, view.Entity.Parents, types.NewEntityUIDSet(types.NewEntityUID("NS::Action", "readOnly")))
 }
 
 func TestResolveActionContextNull(t *testing.T) {

--- a/x/exp/schema/schema_test.go
+++ b/x/exp/schema/schema_test.go
@@ -556,7 +556,7 @@ var wantResolved = &resolved.Schema{
 	},
 	Actions: map[types.EntityUID]resolved.Action{
 		types.NewEntityUID("Action", "audit"): {
-			Name: "audit",
+			Entity: types.Entity{UID: types.NewEntityUID("Action", "audit"), Parents: types.NewEntityUIDSet()},
 			AppliesTo: &resolved.AppliesTo{
 				Principals: []types.EntityType{"Admin"},
 				Resources:  []types.EntityType{"MyApp::Document", "System"},
@@ -564,7 +564,7 @@ var wantResolved = &resolved.Schema{
 			},
 		},
 		types.NewEntityUID("MyApp::Action", "edit"): {
-			Name:        "edit",
+			Entity:      types.Entity{UID: types.NewEntityUID("MyApp::Action", "edit"), Parents: types.NewEntityUIDSet()},
 			Annotations: resolved.Annotations{"doc": "View or edit document"},
 			AppliesTo: &resolved.AppliesTo{
 				Principals: []types.EntityType{"MyApp::User"},
@@ -576,7 +576,7 @@ var wantResolved = &resolved.Schema{
 			},
 		},
 		types.NewEntityUID("MyApp::Action", "manage"): {
-			Name: "manage",
+			Entity: types.Entity{UID: types.NewEntityUID("MyApp::Action", "manage"), Parents: types.NewEntityUIDSet()},
 			AppliesTo: &resolved.AppliesTo{
 				Principals: []types.EntityType{"MyApp::User"},
 				Resources:  []types.EntityType{"MyApp::Document", "MyApp::Group"},
@@ -584,7 +584,7 @@ var wantResolved = &resolved.Schema{
 			},
 		},
 		types.NewEntityUID("MyApp::Action", "view"): {
-			Name:        "view",
+			Entity:      types.Entity{UID: types.NewEntityUID("MyApp::Action", "view"), Parents: types.NewEntityUIDSet()},
 			Annotations: resolved.Annotations{"doc": "View or edit document"},
 			AppliesTo: &resolved.AppliesTo{
 				Principals: []types.EntityType{"MyApp::User"},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After all, an Action _is_ an Entity, albeit one that can't have attributes or tags. This is convenient for callers who, for example, want to add an Action entity from the schema into an EntityMap.

