### PR TITLE
x/exp/schema: accept JSON type shorthand for common-type names

### DIFF
--- a/x/exp/schema/internal/json/json.go
+++ b/x/exp/schema/internal/json/json.go
@@ -418,7 +418,11 @@ func unmarshalType(jt *jsonType) (ast.IsType, error) {
 	case "EntityOrCommon":
 		return ast.TypeRef(jt.Name), nil
 	default:
-		return nil, fmt.Errorf("unknown type %q", jt.Type)
+		// Per the Cedar JSON schema spec, the "type" field may directly contain
+		// the name of a common type or entity type (e.g. {"type": "PersonType"}).
+		// Treat any unrecognized identifier as an EntityOrCommon reference; the
+		// resolver disambiguates and reports undefined names.
+		return ast.TypeRef(jt.Type), nil
 	}
 }
 

--- a/x/exp/schema/internal/json/json_internal_test.go
+++ b/x/exp/schema/internal/json/json_internal_test.go
@@ -116,15 +116,51 @@ func TestMarshalNamespacedError(t *testing.T) {
 	testutil.Error(t, err)
 }
 
+func TestUnmarshalCommonTypeShorthand(t *testing.T) {
+	// A non-builtin "type" string is parsed as an EntityOrCommon reference;
+	// resolution of the referenced name happens later.
+	ns, err := unmarshalNamespace(jsonNamespace{
+		EntityTypes: map[string]jsonEntityType{},
+		Actions:     map[string]jsonAction{},
+		CommonTypes: map[string]jsonCommonType{
+			"Alias": {jsonType: jsonType{Type: "PersonType"}},
+		},
+	})
+	testutil.OK(t, err)
+	testutil.Equals(t, ns.CommonTypes["Alias"].Type, ast.IsType(ast.TypeRef("PersonType")))
+}
+
+// A Set type without an "element" field is the only remaining parse-time
+// error from unmarshalType. The next few tests exercise that error
+// propagating up through each nesting level of unmarshalNamespace and its
+// helpers.
+
 func TestUnmarshalCommonTypeError(t *testing.T) {
 	_, err := unmarshalNamespace(jsonNamespace{
 		EntityTypes: map[string]jsonEntityType{},
 		Actions:     map[string]jsonAction{},
 		CommonTypes: map[string]jsonCommonType{
-			"Bad": {jsonType: jsonType{Type: "Unknown"}},
+			"Bad": {jsonType: jsonType{Type: "Set"}},
 		},
 	})
 	testutil.Error(t, err)
+}
+
+func TestUnmarshalEntityShapeShorthand(t *testing.T) {
+	ns, err := unmarshalNamespace(jsonNamespace{
+		EntityTypes: map[string]jsonEntityType{
+			"Foo": {Shape: &jsonType{
+				Type: "Record",
+				Attributes: map[string]jsonAttr{
+					"bar": {jsonType: jsonType{Type: "PersonType"}},
+				},
+			}},
+		},
+		Actions: map[string]jsonAction{},
+	})
+	testutil.OK(t, err)
+	shape := ns.Entities["Foo"].Shape
+	testutil.Equals(t, shape["bar"].Type, ast.IsType(ast.TypeRef("PersonType")))
 }
 
 func TestUnmarshalEntityShapeError(t *testing.T) {
@@ -133,7 +169,7 @@ func TestUnmarshalEntityShapeError(t *testing.T) {
 			"Foo": {Shape: &jsonType{
 				Type: "Record",
 				Attributes: map[string]jsonAttr{
-					"bad": {jsonType: jsonType{Type: "Unknown"}},
+					"bad": {jsonType: jsonType{Type: "Set"}},
 				},
 			}},
 		},
@@ -153,31 +189,64 @@ func TestUnmarshalActionAnnotations(t *testing.T) {
 	testutil.Equals(t, ns.Actions["view"].Annotations["doc"], types.String("test"))
 }
 
+func TestUnmarshalContextTypeShorthand(t *testing.T) {
+	ns, err := unmarshalNamespace(jsonNamespace{
+		EntityTypes: map[string]jsonEntityType{},
+		Actions: map[string]jsonAction{
+			"view": {AppliesTo: &jsonAppliesTo{
+				Context: &jsonType{Type: "ContextType"},
+			}},
+		},
+	})
+	testutil.OK(t, err)
+	testutil.Equals(t, ns.Actions["view"].AppliesTo.Context, ast.IsType(ast.TypeRef("ContextType")))
+}
+
 func TestUnmarshalContextTypeError(t *testing.T) {
 	_, err := unmarshalNamespace(jsonNamespace{
 		EntityTypes: map[string]jsonEntityType{},
 		Actions: map[string]jsonAction{
 			"view": {AppliesTo: &jsonAppliesTo{
-				Context: &jsonType{Type: "Unknown"},
+				Context: &jsonType{Type: "Set"},
 			}},
 		},
 	})
 	testutil.Error(t, err)
 }
 
+func TestUnmarshalSetElementShorthand(t *testing.T) {
+	got, err := unmarshalType(&jsonType{
+		Type:    "Set",
+		Element: &jsonType{Type: "PersonType"},
+	})
+	testutil.OK(t, err)
+	testutil.Equals(t, got, ast.IsType(ast.SetType{Element: ast.TypeRef("PersonType")}))
+}
+
 func TestUnmarshalSetElementError(t *testing.T) {
 	_, err := unmarshalType(&jsonType{
 		Type:    "Set",
-		Element: &jsonType{Type: "Unknown"},
+		Element: &jsonType{Type: "Set"},
 	})
 	testutil.Error(t, err)
+}
+
+func TestUnmarshalRecordAttrShorthand(t *testing.T) {
+	got, err := unmarshalRecordType(&jsonType{
+		Type: "Record",
+		Attributes: map[string]jsonAttr{
+			"bar": {jsonType: jsonType{Type: "PersonType"}},
+		},
+	})
+	testutil.OK(t, err)
+	testutil.Equals(t, got["bar"].Type, ast.IsType(ast.TypeRef("PersonType")))
 }
 
 func TestUnmarshalRecordAttrError(t *testing.T) {
 	_, err := unmarshalRecordType(&jsonType{
 		Type: "Record",
 		Attributes: map[string]jsonAttr{
-			"bad": {jsonType: jsonType{Type: "Unknown"}},
+			"bad": {jsonType: jsonType{Type: "Set"}},
 		},
 	})
 	testutil.Error(t, err)

--- a/x/exp/schema/internal/json/json_test.go
+++ b/x/exp/schema/internal/json/json_test.go
@@ -234,9 +234,12 @@ func TestUnmarshalBadNamespace(t *testing.T) {
 	testutil.Error(t, s.UnmarshalJSON([]byte(`{"NS": "bad"}`)))
 }
 
-func TestUnmarshalBadType(t *testing.T) {
+func TestUnmarshalShorthandCommonTypeRef(t *testing.T) {
+	// Per the Cedar JSON schema spec, the "type" field may directly hold a
+	// common-type or entity-type name. The parser must accept this form;
+	// undefined-name validation happens at resolve time.
 	var s schemajson.Schema
-	testutil.Error(t, s.UnmarshalJSON([]byte(`{"": {"entityTypes": {"Foo": {"tags": {"type": "Unknown"}}}, "actions": {}}}`)))
+	testutil.OK(t, s.UnmarshalJSON([]byte(`{"": {"entityTypes": {"Foo": {"tags": {"type": "Unknown"}}}, "actions": {}}}`)))
 }
 
 func TestUnmarshalSetMissingElement(t *testing.T) {


### PR DESCRIPTION
Fixes #146.

Per the [Cedar JSON schema spec](https://docs.cedarpolicy.com/schema/json-schema.html#schema-attributes-types), the `type` field of an attribute may directly contain a common-type or entity-type name (the shorthand form), e.g.:

```json
"personInformation": { "type": "PersonType" }
```

This is equivalent to the explicit form:

```json
"personInformation": { "type": "EntityOrCommon", "name": "PersonType" }
```

The cedar-go JSON parser previously rejected anything outside the fixed set of type kinds (`String`, `Long`, `Boolean`, `Extension`, `Set`, `Record`, `Entity`, `EntityOrCommon`), so the canonical PhotoApp example from the Cedar docs and Playground failed at parse time with `unknown type "PersonType"`.

This PR changes the JSON schema parser to accept the shorthand form, which is then later goes through the normal type resolution path.