### PR TITLE
x/exp/schema/validate: handle cyclic entity-type parent declarations

### DIFF
--- a/x/exp/schema/validate/cedar_type.go
+++ b/x/exp/schema/validate/cedar_type.go
@@ -544,15 +544,26 @@ func entityLUBsRelated(a, b entityLUB) bool {
 
 // isEntityDescendant returns true if childType can be a descendant (member) of ancestorType.
 // This means childType lists ancestorType (directly or transitively) in its ParentTypes.
+//
+// The walk tracks visited types because the entity-type parent graph may
+// legitimately contain cycles: `entity Team in [Team, Application];` is valid
+// Cedar (the type-level memberOf relation is reflexive for hierarchical
+// types, even though the instance-level hierarchy must be acyclic).
 func (v *Validator) isEntityDescendant(childType, ancestorType types.EntityType) bool {
 	// Entity types always exist in the schema (validated during scope checking).
-	entity := v.schema.Entities[childType]
-	for _, parent := range entity.ParentTypes {
-		if parent == ancestorType {
-			return true
-		}
-		if v.isEntityDescendant(parent, ancestorType) {
-			return true
+	visited := map[types.EntityType]struct{}{childType: {}}
+	stack := []types.EntityType{childType}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, parent := range v.schema.Entities[current].ParentTypes {
+			if parent == ancestorType {
+				return true
+			}
+			if _, seen := visited[parent]; !seen {
+				visited[parent] = struct{}{}
+				stack = append(stack, parent)
+			}
 		}
 	}
 	return false

--- a/x/exp/schema/validate/policy.go
+++ b/x/exp/schema/validate/policy.go
@@ -306,14 +306,28 @@ func (v *Validator) getActionsInSet(uids []types.EntityUID) []types.EntityUID {
 	return result
 }
 
+// isActionDescendant returns true if actionUID lists ancestorUID (directly or
+// transitively) in its parents.
+//
+// The walk tracks visited actions for the same reason as
+// Validator.isEntityDescendant. Cyclic action hierarchies are rejected at
+// schema resolution, so today this is defensive: it keeps the walk
+// terminating if a resolved schema is ever constructed without going through
+// Resolve.
 func (v *Validator) isActionDescendant(actionUID, ancestorUID types.EntityUID) bool {
-	action := v.schema.Actions[actionUID]
-	for parent := range action.Entity.Parents.All() {
-		if parent == ancestorUID {
-			return true
-		}
-		if v.isActionDescendant(parent, ancestorUID) {
-			return true
+	visited := map[types.EntityUID]struct{}{actionUID: {}}
+	stack := []types.EntityUID{actionUID}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for parent := range v.schema.Actions[current].Entity.Parents.All() {
+			if parent == ancestorUID {
+				return true
+			}
+			if _, seen := visited[parent]; !seen {
+				visited[parent] = struct{}{}
+				stack = append(stack, parent)
+			}
 		}
 	}
 	return false

--- a/x/exp/schema/validate/testdata/entity_type_parent_cycle.cedar
+++ b/x/exp/schema/validate/testdata/entity_type_parent_cycle.cedar
@@ -1,0 +1,7 @@
+permit (
+    principal is User,
+    action == Action::"view",
+    resource is Document
+) when {
+    principal in Application::"app"
+};

--- a/x/exp/schema/validate/testdata/entity_type_parent_cycle.cedarschema
+++ b/x/exp/schema/validate/testdata/entity_type_parent_cycle.cedarschema
@@ -1,0 +1,10 @@
+entity Application;
+entity Team in [Team, Application];
+entity User in [Team];
+entity Document;
+
+action "view" appliesTo {
+    principal: User,
+    resource: Document,
+    context: {},
+};

--- a/x/exp/schema/validate/testdata/entity_type_parent_cycle.entities.json
+++ b/x/exp/schema/validate/testdata/entity_type_parent_cycle.entities.json
@@ -1,0 +1,34 @@
+[
+    {
+        "uid": { "type": "Action", "id": "view" },
+        "attrs": {},
+        "parents": []
+    },
+    {
+        "uid": { "type": "Application", "id": "app" },
+        "attrs": {},
+        "parents": []
+    },
+    {
+        "uid": { "type": "Team", "id": "parent" },
+        "attrs": {},
+        "parents": [
+            { "type": "Application", "id": "app" }
+        ]
+    },
+    {
+        "uid": { "type": "Team", "id": "child" },
+        "attrs": {},
+        "parents": [
+            { "type": "Team", "id": "parent" },
+            { "type": "Application", "id": "app" }
+        ]
+    },
+    {
+        "uid": { "type": "User", "id": "alice" },
+        "attrs": {},
+        "parents": [
+            { "type": "Team", "id": "child" }
+        ]
+    }
+]

--- a/x/exp/schema/validate/testdata/entity_type_parent_cycle.json
+++ b/x/exp/schema/validate/testdata/entity_type_parent_cycle.json
@@ -1,0 +1,7 @@
+{
+    "schema": "testdata/entity_type_parent_cycle.cedarschema",
+    "policies": "testdata/entity_type_parent_cycle.cedar",
+    "shouldValidate": true,
+    "entities": "testdata/entity_type_parent_cycle.entities.json",
+    "requests": []
+}

--- a/x/exp/schema/validate/testdata/entity_type_parent_cycle.validation.json
+++ b/x/exp/schema/validate/testdata/entity_type_parent_cycle.validation.json
@@ -1,0 +1,22 @@
+{
+  "policyValidation": {
+    "strict": true,
+    "permissive": true,
+    "perPolicy": {
+      "policy0": {
+        "strict": true,
+        "permissive": true
+      }
+    }
+  },
+  "entityValidation": {
+    "perEntity": {
+      "Action::view": {},
+      "Application::app": {},
+      "Team::parent": {},
+      "Team::child": {},
+      "User::alice": {}
+    }
+  },
+  "requestValidation": []
+}


### PR DESCRIPTION
# Summary

`Validator.isEntityDescendant` walks an entity type's `ParentTypes` recursively with no visited set, so a self-referential or cyclic `memberOf` declaration can make it recurse forever and crash the process with a stack overflow.

The crashing schema is valid Cedar. `entity Team in [Team, Application];` declares that a `Team` can be a member of another `Team` — the type-level `memberOf` relation is naturally reflexive for hierarchical types, even though the instance-level hierarchy must stay acyclic. This exact shape is in the TinyTodo schema (`entity Team in [Team, Application];` appears in cedar-policy-core's own validator fixtures), so it isn't a contrived input.

The crash is declaration-order dependent. A descendance check only diverges when the walk enters the cycle before it reaches the type it's looking for. For `Team in [Team, Application]`, checking whether a `User` (which is `in [Team]`) is a descendant of `Application` walks User → Team, then follows the Team → Team edge first and never examines Team → Application. If `Application` had been listed first, or if the check were for membership in Team, it would return on the first hop and the bug would stay hidden — which is why acyclic-looking test suites pass while a real schema crashes.

# Fix

Replace the recursion in `isEntityDescendant` with an iterative walk over an explicit stack and a visited set. Behavior is unchanged for acyclic graphs; cyclic graphs now terminate.

`isActionDescendant` has the identical structure and the same latent non-termination. Cyclic action hierarchies are already rejected at schema resolution (resolve.go runs cycle detection over the action hierarchy), so that path is unreachable through the normal Resolve flow today — but the function shouldn't be the one place a future caller, or a hand-built Schema, can wedge the validator. It gets the same iterative treatment, noted in a comment as defensive.

# Test

New corpus entry `entity_type_parent_cycle` reproduces the crash: a TinyTodo-shaped schema (`entity Team in [Team, Application];`) and a policy whose `in Application::"app"` condition forces the walk through the self-referential Team edge. On main it overflows the stack; with the fix it validates cleanly. The full suite, golangci-lint, and the 100%-per-function coverage gate all pass; both modified functions report 100% coverage.