### PR TITLE
parser: accept annotations without a value

### DIFF
--- a/internal/parser/cedar_parse_test.go
+++ b/internal/parser/cedar_parse_test.go
@@ -82,6 +82,19 @@ func TestParse(t *testing.T) {
 				action,
 				resource
 			  );`, false},
+		{"bareAnnotation", `@bare
+			  permit(
+				principal,
+				action,
+				resource
+			  );`, false},
+		{"bareAndValuedAnnotations", `@bare
+			  @valued("v")
+			  permit(
+				principal,
+				action,
+				resource
+			  );`, false},
 
 		// Additional success cases
 		{"primaryInt", `permit(principal, action, resource) when { 1234 };`, false},
@@ -312,6 +325,8 @@ func TestParse(t *testing.T) {
 		{"invalidIs", `permit (principal is 1, action, resource);`, true},
 		{"invalidIsLong", `permit (principal is X::1, action, resource);`, true},
 		{"duplicateAnnotations", `@key("value") @key("value") permit (principal, action, resource);`, true},
+		{"duplicateBareAnnotations", `@key @key permit (principal, action, resource);`, true},
+		{"duplicateBareAndValuedAnnotations", `@key @key("value") permit (principal, action, resource);`, true},
 
 		{"very-negative-long-bad", `permit(principal,action,resource) when { -9223372036823454775808 < -9224323372036854775807 };`, true},
 		{"very-positive-long-bad", `permit(principal,action,resource) when { 9223372036823454775808 < 9224323372036854775807 };`, true},

--- a/internal/parser/cedar_unmarshal.go
+++ b/internal/parser/cedar_unmarshal.go
@@ -187,7 +187,6 @@ func (p *parser) annotations() (ast.Annotations, error) {
 }
 
 func (p *parser) annotation(a *ast.Annotations, known *mapset.MapSet[string]) error {
-	var err error
 	t := p.advance()
 	// As of 2024-09-13, the ability to use reserved keywords for annotation keys is not documented in the Cedar schema.
 	// This ability was added to the Rust implementation in this commit:
@@ -196,23 +195,28 @@ func (p *parser) annotation(a *ast.Annotations, known *mapset.MapSet[string]) er
 		return p.errorf("expected ident or reserved keyword")
 	}
 	name := t.Text
-	if err = p.exact("("); err != nil {
-		return err
-	}
 	if known.Contains(name) {
 		return p.errorf("duplicate annotation: @%s", name)
 	}
 	known.Add(name)
-	t = p.advance()
-	if !t.isString() {
-		return p.errorf("expected string")
-	}
-	value, err := t.stringValue()
-	if err != nil {
-		return err
-	}
-	if err = p.exact(")"); err != nil {
-		return err
+
+	// The annotation value is optional: a bare `@name` is shorthand for
+	// `@name("")`. This matches the Cedar grammar, which made the value
+	// optional in cedar-policy/cedar 4.2.0 (resolving cedar-policy/cedar#1031).
+	var value string
+	if p.peek().Text == "(" {
+		p.advance() // consume "("
+		t = p.advance()
+		if !t.isString() {
+			return p.errorf("expected string")
+		}
+		var err error
+		if value, err = t.stringValue(); err != nil {
+			return err
+		}
+		if err = p.exact(")"); err != nil {
+			return err
+		}
 	}
 
 	a.Annotation(types.Ident(name), types.String(value))

--- a/internal/parser/cedar_unmarshal_test.go
+++ b/internal/parser/cedar_unmarshal_test.go
@@ -491,6 +491,77 @@ when { (if true then 2 else 3) * 4 == 8 };`,
 	}
 }
 
+func TestParseValuelessAnnotation(t *testing.T) {
+	t.Parallel()
+
+	// A bare `@name` annotation is shorthand for `@name("")`. The parser
+	// accepts both forms and produces an identical AST; see cedar-policy/cedar
+	// 4.2.0 (resolving cedar-policy/cedar#1031).
+	parseTests := []struct {
+		Name           string
+		Text           string
+		ExpectedPolicy *ast.Policy
+	}{
+		{
+			"bare annotation",
+			`@foo
+permit ( principal, action, resource );`,
+			ast.Annotation("foo", "").Permit(),
+		},
+		{
+			"bare reserved keyword annotation key",
+			`@is
+permit ( principal, action, resource );`,
+			ast.Annotation("is", "").Permit(),
+		},
+		{
+			"bare annotation preceding a valued one",
+			`@foo
+@baz("quux")
+permit ( principal, action, resource );`,
+			ast.Annotation("foo", "").Annotation("baz", "quux").Permit(),
+		},
+		{
+			"two distinct bare annotations",
+			`@foo
+@bar
+permit ( principal, action, resource );`,
+			ast.Annotation("foo", "").Annotation("bar", "").Permit(),
+		},
+	}
+
+	for _, tt := range parseTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var policy parser.Policy
+			testutil.OK(t, policy.UnmarshalCedar([]byte(tt.Text)))
+			policy.Position = ast.Position{}
+			testutil.Equals(t, &policy, (*parser.Policy)(tt.ExpectedPolicy))
+		})
+	}
+}
+
+func TestValuelessAnnotationEquivalentToEmptyString(t *testing.T) {
+	t.Parallel()
+
+	var bare, explicit parser.Policy
+	testutil.OK(t, bare.UnmarshalCedar([]byte(`@foo
+permit ( principal, action, resource );`)))
+	testutil.OK(t, explicit.UnmarshalCedar([]byte(`@foo("")
+permit ( principal, action, resource );`)))
+	bare.Position = ast.Position{}
+	explicit.Position = ast.Position{}
+	testutil.Equals(t, &bare, &explicit)
+
+	// Marshaling normalizes the empty value back to the explicit `@foo("")`
+	// form, which parses on every Cedar version.
+	var buf bytes.Buffer
+	bare.MarshalCedar(&buf)
+	testutil.Equals(t, buf.String(), `@foo("")
+permit ( principal, action, resource );`)
+}
+
 func TestParseTrailingCommas(t *testing.T) {
 	t.Parallel()
 	parseTests := []struct {


### PR DESCRIPTION
## Summary

Makes the value of a policy annotation optional in the textual parser, so a bare `@name` is accepted as shorthand for `@name("")`.

This matches the Cedar reference grammar, which made the annotation value optional in [cedar-policy/cedar 4.2.0](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/CHANGELOG.md) ("Annotations without explicit values", resolving cedar-policy/cedar#1031). Before this change, cedar-go rejected the bare form with a parse error (`exact got permit want (`).

## Details

- `internal/parser/cedar_unmarshal.go`: the `("...")` group is now optional. An absent value yields `""`, identical to `@name("")` — consistent with how Cedar collapses an absent annotation value to the empty string in its AST.
- The duplicate-annotation check moved ahead of the optional value parse, so duplicates are detected uniformly across bare and valued forms. One observable side effect: an input like `@key @key(...)` now reports `duplicate annotation: @key` rather than a syntax error on the value — a clearer message, and not a behavior change (both forms were already rejected).
- The marshaler is intentionally unchanged: an empty value still serializes as `@name("")`. That form parses on every Cedar version, so this PR is a strict superset of accepted inputs with no change to existing output.

## Testing

- New positive cases: bare annotation, bare reserved-keyword key, two distinct bare annotations, and bare-preceding-valued.
- New error cases: duplicate bare annotations, and duplicate across bare + valued forms.
- A test asserting `@foo` and `@foo("")` parse to identical ASTs, and that an empty value marshals back to `@foo("")`.
- `go test ./...`, `go vet ./...`, and `gofmt -l` are clean.
