### PR TITLE
Reject IPv4-mapped IPv6 addresses in IPAddr's IsLoopback and IsMulticast

### DIFF
--- a/types/ipaddr.go
+++ b/types/ipaddr.go
@@ -73,6 +73,15 @@ func (i IPAddr) IsLoopback() bool {
 	// 		The reason for IpV4 is that provided the truncated ip address is a
 	// 		loopback address, its prefix cannot be less than 8 because
 	// 		otherwise its more significant byte cannot be 127
+	if i.Addr().Is4In6() {
+		// The Rust standard library, and therefore Cedar Rust, does not unwrap
+		// IPv4-mapped IPv6 addresses, so an address such as ::ffff:127.0.0.1
+		// is treated as a plain IPv6 address and not loopback.
+		// Since the Go's standard library behaves differently and unwraps such
+		// addresses, explicitly check for that case to match Cedar Rust.
+		// No IPv4-mapped IPv6 address can be the IPv6 loopback address (::1).
+		return false
+	}
 	return i.Prefix().Masked().Addr().IsLoopback()
 }
 
@@ -93,6 +102,15 @@ func (i IPAddr) IsMulticast() bool {
 	// 		The implementation uses the property that if `ip1/prefix1` is in
 	// 		range `ip2/prefix2`, then `ip1` is in `ip2/prefix2` and `prefix1 >=
 	// 		prefix2`
+	if i.Addr().Is4In6() {
+		// The Rust standard library, and therefore Cedar Rust, does not unwrap
+		// IPv4-mapped IPv6 addresses, so an address such as ::ffff:224.0.0.0 is
+		// treated as a plain IPv6 address and not multicast.
+		// Since the Go's standard library behaves differently and unwraps such
+		// addresses, explicitly check for that case to match Cedar Rust.
+		// No IPv4-mapped IPv6 address falls in the IPv6 multicast range (ff00::/8).
+		return false
+	}
 	var minPrefixLen int
 	if i.IsIPv4() {
 		minPrefixLen = 4

--- a/types/ipaddr_test.go
+++ b/types/ipaddr_test.go
@@ -179,6 +179,8 @@ func TestIP(t *testing.T) {
 			{"::/128", false},
 			{"::1/128", true},
 			{"::1/127", false},
+			{"::ffff:7f00:0001", false},
+			{"::ffff:7f00:0001/128", false},
 			{"::ffff:8000:0001", false},
 			{"::ffff:8000:0002", false},
 			{"::ffff:8000:0001/128", false},
@@ -225,6 +227,8 @@ func TestIP(t *testing.T) {
 			{"ff00::/7", false},
 			{"224.0.0.0/4", true},
 			{"224.0.0.0/3", false},
+			{"::ffff:e000:0000", false},
+			{"::ffff:e000:0000/128", false},
 		}
 		for _, tt := range tests {
 			tt := tt


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/cedar-policy/cedar-go/issues/152

*Description of changes:*

This PR updates IPAddr's IsLoopback and IsMulticast methods to reject IPv4-mapped IPv6 addresses to conform to the behavior of Cedar Rust.

The Rust standard library, and therefore the Cedar Rust implementation, has different behavior from Go's standard library with respect to IPv4-mapped IPv6 addresses.

In Cedar Rust, an IPv4 loopback address encoded as an IPv4-mapped IPv6 address (such as ::ffff:127.0.0.1) is not considered to be a valid loopback address.

Similarily, an IPv4 multicast address encoded as an IPv4-mapped IPv6 address (such as ::ffff:224.0.0.0) is not considered to be a valid multicast address.

The Go standard library, in contrast, unwraps such addresses and therefore Cedar Go would consider those addresses to be valid loopback and multicast addresses, respectively.

This patch modifies Cedar Go's IsLoopback and IsMulticast implementation to explicitly check for IPv4-mapped IPv6 addresses and reject those, to conform to the behavior of Cedar Rust.
